### PR TITLE
Loan became overdue event and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Exlibris
-The Librarian application.
+[![codecov.io](https://codecov.io/github/Java-Classes/Exlibris/coverage.svg?branch=master)](https://codecov.io/github/Java-Classes/Exlibris/core-java?branch=master) &nbsp;
+<p>The Librarian application.

--- a/api-java/src/main/java/javaclasses/exlibris/c/aggregate/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/aggregate/InventoryAggregate.java
@@ -160,6 +160,10 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                                 .setInventoryId(inventoryId)
                                                 .setInventoryItemId(inventoryItemId)
                                                 .setWhoBorrowed(userId)
+                                                .setLoanId(LoanId.newBuilder()
+                                                                 .setValue(
+                                                                         getCurrentTime().getSeconds())
+                                                                 .build())
                                                 .setWhenBorrowed(getCurrentTime())
                                                 .build();
         return singletonList(result);
@@ -321,18 +325,18 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                                                 event.getInventoryItemId())
                                                         .build();
 
-        final int secondsInTwoWeeks = 1209600;
+        // The loan period time is seconds.
+        final int loanPeriod = 1209600;
+
         final Loan loan = Loan.newBuilder()
-                              .setLoanId(LoanId.newBuilder()
-                                               .setValue(getCurrentTime().getSeconds())
-                                               .build())
+                              .setLoanId(event.getLoanId())
                               .setInventoryItemId(event.getInventoryItemId())
                               .setOverdue(false)
                               .setWhoBorrowed(event.getWhoBorrowed())
                               .setWhenTaken(getCurrentTime())
                               .setWhenDue(Timestamp.newBuilder()
                                                    .setSeconds(System.currentTimeMillis() / 1000 +
-                                                                       secondsInTwoWeeks)
+                                                                       loanPeriod)
                                                    .build())
                               .build();
 
@@ -349,7 +353,8 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         for (int i = 0; i < loans.size(); i++) {
             if (loans.get(i)
                      .getLoanId()
-                     .equals(event.getLoanId())) {
+                     .getValue() == event.getLoanId()
+                                         .getValue()) {
                 loanPosition = i;
             }
         }

--- a/api-java/src/main/java/javaclasses/exlibris/c/aggregate/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/aggregate/InventoryAggregate.java
@@ -62,7 +62,6 @@ import java.util.List;
 
 import static io.spine.time.Time.getCurrentTime;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.sort;
 
 /**
  * The aggregate managing the state of a {@link Inventory}.
@@ -326,7 +325,9 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                                                 event.getInventoryItemId())
                                                         .build();
 
-        // The loan period time is seconds.
+        // The loan period time in seconds.
+        // This period is equals two weeks.
+        // secondsInMinute * minutesInHour * hoursInDay * daysInTwoWeeks = 1209600.
         final int loanPeriod = 1209600;
 
         final Loan loan = Loan.newBuilder()

--- a/api-java/src/test/java/io/spine/javaclasses/exlibris/c/aggregate/definition/MarkLoanOverdueCommandTest.java
+++ b/api-java/src/test/java/io/spine/javaclasses/exlibris/c/aggregate/definition/MarkLoanOverdueCommandTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.javaclasses.exlibris.c.aggregate.definition;
+
+import com.google.protobuf.Message;
+import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.LoanId;
+import javaclasses.exlibris.c.AppendInventory;
+import javaclasses.exlibris.c.BookBorrowed;
+import javaclasses.exlibris.c.BorrowBook;
+import javaclasses.exlibris.c.LoanBecameOverdue;
+import javaclasses.exlibris.c.MarkLoanOverdue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
+import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Dmytry Dyachenko
+ */
+@DisplayName("MarkLoanOverdue command should be interpreted by InventoryAggregate and")
+public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOverdue> {
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    @DisplayName("produce LoanBecameOverdue event")
+    void produceEvent() {
+        dispatchAppendInventory();
+        final LoanId eventLoanId = dispatchBorrowBookAndReturnLoanId();
+
+        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(eventLoanId, inventoryId);
+
+        final List<? extends Message> messageList = dispatchCommand(aggregate,
+                                                                    envelopeOf(markLoanOverdue));
+        assertEquals(1, messageList.size());
+        assertEquals(LoanBecameOverdue.class, messageList.get(0)
+                                                         .getClass());
+        final LoanBecameOverdue loanBecameOverdue = (LoanBecameOverdue) messageList.get(0);
+
+        assertEquals(eventLoanId, loanBecameOverdue.getLoanId());
+
+    }
+
+    @Test
+    @DisplayName("marks loan as overdue")
+    void markLoanPeriodAsOverdue() {
+        dispatchAppendInventory();
+        final LoanId eventLoanId = dispatchBorrowBookAndReturnLoanId();
+
+        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(eventLoanId, inventoryId);
+
+        dispatchCommand(aggregate, envelopeOf(markLoanOverdue));
+        final Inventory state = aggregate.getState();
+
+        assertTrue(state.getInventoryItems(0)
+                        .getBorrowed());
+
+        assertTrue(state.getLoans(0)
+                        .getOverdue());
+
+    }
+
+    private void dispatchAppendInventory() {
+        final AppendInventory appendInventory = appendInventoryInstance();
+        dispatchCommand(aggregate, envelopeOf(appendInventory));
+    }
+
+    private LoanId dispatchBorrowBookAndReturnLoanId() {
+        final BorrowBook borrowBook = borrowBookInstance();
+
+        final List<? extends Message> messages = dispatchCommand(aggregate, envelopeOf(borrowBook));
+        final BookBorrowed bookBorrowed = (BookBorrowed) messages.get(0);
+        return bookBorrowed.getLoanId();
+    }
+
+}

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -141,8 +141,11 @@ message BookBorrowed {
     // Who borrowed a book.
     UserId who_borrowed = 3;
 
+    // The loan period.
+    LoanId loan_id = 4;
+
     // The time when user borrowed a book.
-    google.protobuf.Timestamp when_borrowed = 4;
+    google.protobuf.Timestamp when_borrowed = 5;
 }
 
 // An event when a reservation was successfully finished.

--- a/testutil-api/src/main/java/io/spine/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/io/spine/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -25,15 +25,20 @@ import javaclasses.exlibris.BookId;
 import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.InventoryItemId;
 import javaclasses.exlibris.Isbn62;
+import javaclasses.exlibris.LoanId;
 import javaclasses.exlibris.Rfid;
 import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.WriteOffReason;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.CancelReservation;
+import javaclasses.exlibris.c.MarkLoanOverdue;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.ReturnBook;
 import javaclasses.exlibris.c.WriteBookOff;
+
+import static io.spine.time.Time.getCurrentTime;
+
 /**
  * A factory of the task commands for the test needs.
  *
@@ -54,6 +59,9 @@ public class InventoryCommandFactory {
     public static final UserId userId = UserId.newBuilder()
                                               .setEmail(EmailAddress.newBuilder()
                                                                     .setValue("petr@gmail.com"))
+                                              .build();
+    public static final LoanId loanId = LoanId.newBuilder()
+                                              .setValue(getCurrentTime().getSeconds())
                                               .build();
     public static final Rfid rfid = Rfid.newBuilder()
                                         .setValue("4321")
@@ -98,6 +106,14 @@ public class InventoryCommandFactory {
                                             .setInventoryItemId(inventoryItemId)
                                             .setUserId(userId)
                                             .build();
+        return result;
+    }
+
+    public static MarkLoanOverdue markLoanOverdue(LoanId loanId, InventoryId inventoryId) {
+        final MarkLoanOverdue result = MarkLoanOverdue.newBuilder()
+                                                      .setLoanId(loanId)
+                                                      .setInventoryId(inventoryId)
+                                                      .build();
         return result;
     }
 
@@ -148,17 +164,19 @@ public class InventoryCommandFactory {
                                                     .build();
         return result;
     }
+
     public static ReturnBook returnBookInstance() {
 
-        final ReturnBook result = returnBookInstance(inventoryId, inventoryItemId,userId);
+        final ReturnBook result = returnBookInstance(inventoryId, inventoryItemId, userId);
         return result;
     }
 
-    public static ReturnBook returnBookInstance(InventoryId inventoryId, InventoryItemId inventoryItemId, UserId userId) {
+    public static ReturnBook returnBookInstance(InventoryId inventoryId,
+                                                InventoryItemId inventoryItemId, UserId userId) {
         ReturnBook result = ReturnBook.newBuilder()
-                                        .setInventoryId(inventoryId)
-                                        .setUserId(userId)
-                                        .build();
+                                      .setInventoryId(inventoryId)
+                                      .setUserId(userId)
+                                      .build();
         return result;
     }
 }

--- a/testutil-api/src/main/java/io/spine/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/io/spine/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -39,9 +39,6 @@ import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.ReturnBook;
 import javaclasses.exlibris.c.WriteBookOff;
 
-import static io.spine.time.Time.getCurrentTime;
-
-
 /**
  * A factory of the task commands for the test needs.
  *
@@ -177,9 +174,6 @@ public class InventoryCommandFactory {
                                                 InventoryItemId inventoryItemId, UserId userId) {
         ReturnBook result = ReturnBook.newBuilder()
                                       .setInventoryId(inventoryId)
-                                      .setUserId(userId)
-                                      .build();
-                                      .setInventoryId(inventoryId)
                                       .setInventoryItemId(inventoryItemId)
                                       .setUserId(userId)
                                       .build();
@@ -218,18 +212,4 @@ public class InventoryCommandFactory {
                                                               .build();
         return result;
     }
-
-//    public static ReturnBook returnBookInstance() {
-//
-//        final ReturnBook result = returnBookInstance(userId, inventoryId);
-//        return result;
-//    }
-//
-//    public static ReturnBook returnBookInstance(InventoryId inventoryId, InventoryItemId inventoryItemId, UserId userId) {
-//        ReturnBook result = ReturnBook.newBuilder()
-//                                        .setInventoryId(inventoryId)
-//                                        .setUserId(userId)
-//                                        .build();
-//        return result;
-//    }
 }


### PR DESCRIPTION
Get `loanId` from the `BookBorrowed` event wasn’t possible. 
It is necessary to take the information about the loan and mark it as overdue.
Also missed tests for the `MarkLoanOverdue` command and `LoanBecameOverdue` event.

- Add `loanId` field to the `BookBorrowed` event in the `event.proto` file. 
- Change the `BorrowBook` assign rewritten the `BookBorrowed` builder.
```
 BookBorrowed.newBuilder()
.setInventoryId(inventoryId)
.setInventoryItemId(inventoryItemId)
.setWhoBorrowed(userId)
.setLoanId(LoanId.newBuilder() .setValue(getCurrentTime().getSeconds()).build())
.setWhenBorrowed(getCurrentTime())
.build();
```
- Write the test to produce the `LoanBecameOverdue` event.
- Write the test to check that loan is marked as overdue.
