### PR TITLE
Restructured the project

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
   ignore:
   - generated/*
   - test/*
-  - testutil-api/src/main/java/io/spine/javaclasses/exlibris/testdata/*
+  - testutil-api/src/main/java/javaclasses/exlibris/testdata/*
 
   status:
     patch: false

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/AddBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/AddBookCommandTest.java
@@ -18,26 +18,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.BookCommandFactory;
 import javaclasses.exlibris.Book;
 import javaclasses.exlibris.BookId;
 import javaclasses.exlibris.BookTitle;
 import javaclasses.exlibris.c.AddBook;
 import javaclasses.exlibris.c.BookAdded;
 import javaclasses.exlibris.c.rejection.BookAlreadyExists;
+import javaclasses.exlibris.testdata.BookCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.userId;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.userId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/AppendInventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/AppendInventoryCommandTest.java
@@ -18,18 +18,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.InventoryAppended;
 import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -105,7 +107,6 @@ public class AppendInventoryCommandTest extends InventoryCommandTest<AppendInven
                                   .getUserId()
                                   .getEmail()
                                   .getValue());
-        System.out.println(inventory);
     }
     @Test
     @DisplayName("append inventory with reservation")
@@ -116,7 +117,6 @@ public class AppendInventoryCommandTest extends InventoryCommandTest<AppendInven
         final AppendInventory appendInventory = InventoryCommandFactory.appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
         final Inventory inventory = aggregate.getState();
-        System.out.println(inventory);
         assertEquals(1, inventory.getInventoryItemsList()
                                  .size());
         assertTrue(inventory.getInventoryItemsList()

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/BookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/BookCommandTest.java
@@ -18,40 +18,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
 import io.spine.client.TestActorRequestFactory;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.AggregateCommandTest;
 import javaclasses.exlibris.BookId;
-import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.Isbn62;
-import javaclasses.exlibris.c.aggregate.InventoryAggregate;
 
 /**
- * @author Alexander Karpets
+ * @author Paul Ageyev
  */
-public class InventoryCommandTest<C extends Message> extends AggregateCommandTest<C, InventoryAggregate> {
+abstract class BookCommandTest<C extends Message> extends AggregateCommandTest<C, BookAggregate> {
+
     private final TestActorRequestFactory requestFactory =
             TestActorRequestFactory.newInstance(getClass());
 
-    InventoryAggregate aggregate;
-    InventoryId inventoryId;
+    BookAggregate aggregate;
+    BookId bookId;
 
-    private static InventoryId createBookId() {
+    private static BookId createBookId() {
 
-        return InventoryId.newBuilder()
-                          .setBookId(BookId.newBuilder()
-                                           .setIsbn62(Isbn62.newBuilder()
-                                                            .setValue("123456789")))
-                          .build();
+        return BookId.newBuilder()
+                     .setIsbn62(Isbn62.newBuilder()
+                                      .setValue("1"))
+                     .build();
     }
 
     @Override
-    protected InventoryAggregate createAggregate() {
-        inventoryId = createBookId();
-        return new InventoryAggregate(inventoryId);
+    protected BookAggregate createAggregate() {
+        bookId = createBookId();
+        return new BookAggregate(bookId);
     }
 
     @Override

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/BorrowBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/BorrowBookCommandTest.java
@@ -18,24 +18,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BookBorrowed;
 import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/CancelReservationCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/CancelReservationCommandTest.java
@@ -18,17 +18,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.CancelReservation;
 import javaclasses.exlibris.c.ReservationCanceled;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.rejection.CannotCancelMissingReservation;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ExtendLoanPeriodCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ExtendLoanPeriodCommandTest.java
@@ -18,26 +18,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ExtendLoanPeriod;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.rejection.CannotExtendLoanPeriod;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryCommandTest.java
@@ -18,39 +18,39 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
 import io.spine.client.TestActorRequestFactory;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.AggregateCommandTest;
 import javaclasses.exlibris.BookId;
+import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.Isbn62;
-import javaclasses.exlibris.c.aggregate.BookAggregate;
 
 /**
- * @author Paul Ageyev
+ * @author Alexander Karpets
  */
-abstract class BookCommandTest<C extends Message> extends AggregateCommandTest<C, BookAggregate> {
-
+public class InventoryCommandTest<C extends Message> extends AggregateCommandTest<C, InventoryAggregate> {
     private final TestActorRequestFactory requestFactory =
             TestActorRequestFactory.newInstance(getClass());
 
-    BookAggregate aggregate;
-    BookId bookId;
+    InventoryAggregate aggregate;
+    InventoryId inventoryId;
 
-    private static BookId createBookId() {
+    private static InventoryId createBookId() {
 
-        return BookId.newBuilder()
-                     .setIsbn62(Isbn62.newBuilder()
-                                      .setValue("1"))
-                     .build();
+        return InventoryId.newBuilder()
+                          .setBookId(BookId.newBuilder()
+                                           .setIsbn62(Isbn62.newBuilder()
+                                                            .setValue("123456789")))
+                          .build();
     }
 
     @Override
-    protected BookAggregate createAggregate() {
-        bookId = createBookId();
-        return new BookAggregate(bookId);
+    protected InventoryAggregate createAggregate() {
+        inventoryId = createBookId();
+        return new InventoryAggregate(inventoryId);
     }
 
     @Override

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryCreatedTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryCreatedTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Optional;
 import io.spine.core.Event;
-import io.spine.javaclasses.exlibris.testdata.BookCommandFactory;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.TestEventFactory;
 import io.spine.server.entity.Repository;
@@ -30,8 +29,7 @@ import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.c.AddBook;
 import javaclasses.exlibris.c.BookAdded;
-import javaclasses.exlibris.c.aggregate.BookAggregate;
-import javaclasses.exlibris.c.aggregate.InventoryAggregate;
+import javaclasses.exlibris.testdata.BookCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryRemovedTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/InventoryRemovedTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Optional;
 import io.spine.core.Event;
-import io.spine.javaclasses.exlibris.testdata.BookCommandFactory;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.TestEventFactory;
 import io.spine.server.entity.Repository;
@@ -30,8 +29,7 @@ import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.c.AddBook;
 import javaclasses.exlibris.c.BookRemoved;
-import javaclasses.exlibris.c.aggregate.BookAggregate;
-import javaclasses.exlibris.c.aggregate.InventoryAggregate;
+import javaclasses.exlibris.testdata.BookCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/MarkLoanOverdueCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/MarkLoanOverdueCommandTest.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
 import javaclasses.exlibris.Inventory;
@@ -31,11 +31,13 @@ import javaclasses.exlibris.c.MarkLoanOverdue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/RejectionConstructorsTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/RejectionConstructorsTest.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import javaclasses.exlibris.c.aggregate.rejection.BookAggregateRejections;
 import javaclasses.exlibris.c.aggregate.rejection.InventoryAggregateRejections;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/RemoveBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/RemoveBookCommandTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.BookCommandFactory;
 import javaclasses.exlibris.Book;
 import javaclasses.exlibris.BookId;
 import javaclasses.exlibris.Isbn62;
@@ -30,16 +29,19 @@ import javaclasses.exlibris.c.AddBook;
 import javaclasses.exlibris.c.BookRemoved;
 import javaclasses.exlibris.c.RemoveBook;
 import javaclasses.exlibris.c.rejection.CannotRemoveMissingBook;
+import javaclasses.exlibris.testdata.BookCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.librarianId;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.removalReason;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.userId;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.librarianId;
+import static javaclasses.exlibris.testdata.BookCommandFactory.removalReason;
+import static javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.userId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReportLostBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReportLostBookCommandTest.java
@@ -18,24 +18,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BookLost;
 import javaclasses.exlibris.c.ReportLostBook;
 import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.reportLostBookInstance;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.reportLostBookInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReservationPickUpPeriodExpiredCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReservationPickUpPeriodExpiredCommandTest.java
@@ -18,19 +18,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.c.MarkReservationExpired;
 import javaclasses.exlibris.c.ReservationPickUpPeriodExpired;
 import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.reservationPickUpPeriodInstanceExpired;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.reservationPickUpPeriodInstanceExpired;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReserveBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReserveBookCommandTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.BookId;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
@@ -30,13 +29,16 @@ import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ReservationAdded;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.rejection.CannotReserveBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReturnBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/ReturnBookCommandTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.InventoryItemId;
 import javaclasses.exlibris.c.AppendInventory;
@@ -31,10 +30,13 @@ import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ReturnBook;
 import javaclasses.exlibris.c.rejection.CannotReturnMissingBook;
 import javaclasses.exlibris.c.rejection.CannotReturnNonBorrowedBook;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/TestBoundedContext.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/TestBoundedContext.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import javaclasses.exlibris.context.BoundedContexts;
 import org.junit.jupiter.api.DisplayName;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/UpdateBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/UpdateBookCommandTest.java
@@ -18,11 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.BookCommandFactory;
 import javaclasses.exlibris.Book;
 import javaclasses.exlibris.BookDetailsChange;
 import javaclasses.exlibris.BookId;
@@ -31,15 +30,18 @@ import javaclasses.exlibris.c.AddBook;
 import javaclasses.exlibris.c.BookUpdated;
 import javaclasses.exlibris.c.UpdateBook;
 import javaclasses.exlibris.c.rejection.CannotUpdateMissingBook;
+import javaclasses.exlibris.testdata.BookCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.bookDetails;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.bookDetails2;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-import static io.spine.javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.BookCommandFactory.bookDetails;
+import static javaclasses.exlibris.testdata.BookCommandFactory.bookDetails2;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api-java/src/test/java/javaclasses/exlibris/c/aggregate/WriteBookOffCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/aggregate/WriteBookOffCommandTest.java
@@ -18,21 +18,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.c.aggregate.definition;
+package javaclasses.exlibris.c.aggregate;
 
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
-import io.spine.javaclasses.exlibris.testdata.InventoryCommandFactory;
 import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.InventoryDecreased;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.WriteBookOff;
 import javaclasses.exlibris.c.rejection.CannotWriteMissingBookOff;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
+
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'idea'
 
-    group = 'io.spine.javaclasses.exlibris'       // Generated output GroupId
+    group = 'javaclasses.exlibris'       // Generated output GroupId
     version = appVersion  // Version in generated output. This is the version of the code.
     // For the deployment version see `project.ext.getDeploymentVersion`.
 
@@ -245,7 +245,7 @@ subprojects {
 
         selectors {
             directory "${sourcesRootDir}/test/java"
-            packages 'io.spine.javaclasses.exlibris'
+            packages 'javaclasses.exlibris'
         }
 
         filters {

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookCommandFactory.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.testdata;
+package javaclasses.exlibris.testdata;
 
 import io.spine.net.EmailAddress;
 import io.spine.net.Url;

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.javaclasses.exlibris.testdata;
+package javaclasses.exlibris.testdata;
 
 import io.spine.net.EmailAddress;
 import javaclasses.exlibris.BookId;


### PR DESCRIPTION
Aggregate tests were in the io.spine package.
Util test classes were in io.spine as well.

This PR:

- Tests now in package: `javaclasses.exlibris.c.aggregate`
- Remove package definition which came from step-1 template