### PR TITLE
Exlibris model change.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="100" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <JavaCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />

--- a/.spine/spine_model.ser
+++ b/.spine/spine_model.ser
@@ -1,3 +1,0 @@
-
-)javaclasses.exlibris.c.book.BookAggregate
-3javaclasses.exlibris.c.inventory.InventoryAggregate

--- a/api-java/src/main/java/javaclasses/exlibris/BoundedContexts.java
+++ b/api-java/src/main/java/javaclasses/exlibris/BoundedContexts.java
@@ -28,7 +28,8 @@ import io.spine.server.storage.StorageFactory;
 import io.spine.server.storage.memory.InMemoryStorageFactory;
 import javaclasses.exlibris.c.book.BookRepository;
 import javaclasses.exlibris.c.inventory.InventoryRepository;
-import javaclasses.exlibris.c.procman.ReservationQueueRepository;
+import javaclasses.exlibris.c.procman.LoansExtensionProcmanRepository;
+import javaclasses.exlibris.c.procman.ReservationQueueProcmanRepository;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -73,17 +74,17 @@ public final class BoundedContexts {
 
         final BookRepository bookRepository = new BookRepository();
         final InventoryRepository inventoryRepository = InventoryRepository.getRepository();
-        final ReservationQueueRepository reservationQueueRepository = new ReservationQueueRepository();
+        final ReservationQueueProcmanRepository reservationQueueRepository = new ReservationQueueProcmanRepository();
+        final LoansExtensionProcmanRepository loansExtensionRepository = new LoansExtensionProcmanRepository();
 
         final EventBus.Builder eventBus = createEventBus(storageFactory);
 
         final BoundedContext boundedContext = createBoundedContext(eventBus);
-        boundedContext.getEventBus()
-                      .register(reservationQueueRepository);
 
         boundedContext.register(bookRepository);
         boundedContext.register(inventoryRepository);
         boundedContext.register(reservationQueueRepository);
+        boundedContext.register(loansExtensionRepository);
         return boundedContext;
     }
 

--- a/api-java/src/main/java/javaclasses/exlibris/BoundedContexts.java
+++ b/api-java/src/main/java/javaclasses/exlibris/BoundedContexts.java
@@ -28,6 +28,7 @@ import io.spine.server.storage.StorageFactory;
 import io.spine.server.storage.memory.InMemoryStorageFactory;
 import javaclasses.exlibris.c.book.BookRepository;
 import javaclasses.exlibris.c.inventory.InventoryRepository;
+import javaclasses.exlibris.c.procman.ReservationQueueRepository;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -71,14 +72,18 @@ public final class BoundedContexts {
         checkNotNull(storageFactory);
 
         final BookRepository bookRepository = new BookRepository();
-        final InventoryRepository inventoryRepository = new InventoryRepository();
+        final InventoryRepository inventoryRepository = InventoryRepository.getRepository();
+        final ReservationQueueRepository reservationQueueRepository = new ReservationQueueRepository();
 
         final EventBus.Builder eventBus = createEventBus(storageFactory);
 
         final BoundedContext boundedContext = createBoundedContext(eventBus);
-        boundedContext.register(bookRepository);
+        boundedContext.getEventBus()
+                      .register(reservationQueueRepository);
 
+        boundedContext.register(bookRepository);
         boundedContext.register(inventoryRepository);
+        boundedContext.register(reservationQueueRepository);
         return boundedContext;
     }
 

--- a/api-java/src/main/java/javaclasses/exlibris/c/book/BookRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/book/BookRepository.java
@@ -29,5 +29,4 @@ import javaclasses.exlibris.BookId;
  * @author Alexander Karpets
  */
 public class BookRepository extends AggregateRepository<BookId, BookAggregate> {
-
 }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -623,7 +623,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final InventoryItem newInventoryItem = InventoryItem.newBuilder()
                                                             .setInLibrary(true)
                                                             .setInventoryItemId(inventoryItemId)
-                                                            .setInLibrary(true)
                                                             .build();
         getBuilder().addInventoryItems(newInventoryItem);
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -41,7 +41,6 @@ import javaclasses.exlibris.Loan;
 import javaclasses.exlibris.LoanId;
 import javaclasses.exlibris.LoanStatus;
 import javaclasses.exlibris.Reservation;
-import javaclasses.exlibris.Rfid;
 import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.WriteOffReason;
 import javaclasses.exlibris.c.AppendInventory;
@@ -919,14 +918,12 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     private InventoryAppended createInventoryAppendedEvent(AppendInventory cmd) {
         final InventoryId inventoryId = cmd.getInventoryId();
         final InventoryItemId inventoryItemId = cmd.getInventoryItemId();
-        final Rfid rfid = cmd.getRfid();
         final UserId userId = cmd.getLibrarianId();
 
         final InventoryAppended inventoryAppended =
                 InventoryAppended.newBuilder()
                                  .setInventoryId(inventoryId)
                                  .setInventoryItemId(inventoryItemId)
-                                 .setRfid(rfid)
                                  .setWhenAppended(getCurrentTime())
                                  .setLibrarianId(userId)
                                  .build();

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -511,13 +511,11 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     }
 
     @Apply
-        // TODO 4/26/2018[yegor.udovchenko]: QR code?
     void inventoryAppended(InventoryAppended event) {
         final InventoryItemId inventoryItemId = event.getInventoryItemId();
         final InventoryItem newInventoryItem = InventoryItem.newBuilder()
                                                             .setInLibrary(true)
                                                             .setInventoryItemId(inventoryItemId)
-//                                                            .setQrCodeUrl()
                                                             .build();
         getBuilder().addInventoryItems(newInventoryItem);
     }
@@ -764,7 +762,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         return bookReadyToPickup;
     }
 
-    // TODO 4/26/2018[yegor.udovchenko]: Add QR code url
     private InventoryAppended createInventoryAppendedEvent(AppendInventory cmd) {
         final InventoryId inventoryId = cmd.getInventoryId();
         final InventoryItemId inventoryItemId = cmd.getInventoryItemId();
@@ -776,7 +773,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                  .setInventoryItemId(inventoryItemId)
                                  .setWhenAppended(getCurrentTime())
                                  .setLibrarianId(userId)
-//                                 .setQrCodeUrl()
                                  .build();
         return inventoryAppended;
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -789,9 +789,16 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final InventoryItemId inventoryItemId = cmd.getInventoryItemId();
         final UserId librarianId = cmd.getLibrarianId();
         final WriteOffReason writeOffReason = cmd.getWriteBookOffReason();
+        final List<InventoryItem> inventoryItems = getState().getInventoryItemsList();
+        final int index = getInventoryItemIndexById(inventoryItemId, inventoryItems);
+        final InventoryItem inventoryItem = inventoryItems.get(index);
+
         // current available count should be decreased to match its value
-        // after applying this event.
-        final int availableItemsCount = getAvailableInventoryItemsCount() - 1;
+        // after applying this event. If the book was lost by user it is already
+        // non available.
+        final int availableItemsCount = inventoryItem.getLost()
+                                        ? getAvailableInventoryItemsCount()
+                                        : getAvailableInventoryItemsCount() - 1;
         final InventoryDecreased inventoryDecreased =
                 InventoryDecreased.newBuilder()
                                   .setInventoryId(inventoryId)

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -739,12 +739,12 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final Timestamp currentTime = getCurrentTime();
         // current available count should be increased to match its value
         // after applying this event.
-        final int itemsCount = getAvailableInventoryItemsCount() + 1;
+        final int availableItemsCount = getAvailableInventoryItemsCount() + 1;
         final BookBecameAvailable bookBecameAvailable =
                 BookBecameAvailable.newBuilder()
                                    .setInventoryId(inventoryId)
                                    .setWhenBecameAvailable(currentTime)
-                                   .setInLibraryCount(itemsCount)
+                                   .setAvailableBooksCount(availableItemsCount)
                                    .build();
         return bookBecameAvailable;
     }
@@ -791,7 +791,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final WriteOffReason writeOffReason = cmd.getWriteBookOffReason();
         // current available count should be decreased to match its value
         // after applying this event.
-        final int itemsCount = getAvailableInventoryItemsCount() - 1;
+        final int availableItemsCount = getAvailableInventoryItemsCount() - 1;
         final InventoryDecreased inventoryDecreased =
                 InventoryDecreased.newBuilder()
                                   .setInventoryId(inventoryId)
@@ -799,7 +799,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                   .setWhenDecreased(getCurrentTime())
                                   .setLibrarianId(librarianId)
                                   .setWriteOffReason(writeOffReason)
-                                  .setInLibraryCount(itemsCount)
+                                  .setAvailableBooksCount(availableItemsCount)
                                   .build();
         return inventoryDecreased;
     }
@@ -860,7 +860,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                                       .setLoanId(loanId)
                                                       .setWhenBorrowed(whenBorrowed)
                                                       .setWhenDue(whenDue)
-                                                      .setInLibraryCount(availableItemsCount)
+                                                      .setAvailableBooksCount(availableItemsCount)
                                                       .build();
         return bookBorrowed;
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -145,7 +145,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     }
 
     // @formatter:off
-
     /**
      * Handles a {@code AppendInventory} command.
      *
@@ -153,15 +152,15 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      * <p>Returns the following event combinations:
      *
      * <ul>
-     * <li>{@code InventoryAppended, BookBecameAvailable, null} - when the reservations
-     * list is empty.
-     * <li>{@code InventoryAppended, BookReadyToPickup, null} - when the added item
-     * becomes ready to pick up for the first in the reservations queue and other
-     * readers still have reservations.
-     * <li>{@code InventoryAppended, BookReadyToPickup, LoansBecameExtensionAllowed} - when the
-     * added item becomes ready to pick up for the first in the reservations queue and there aro no
-     * readers in the queue except him. In that case all recent loans of this book
-     * become allowed for extension.
+     *      <li>{@code InventoryAppended, BookBecameAvailable, null} - when the reservations
+     *           list is empty.
+     *      <li>{@code InventoryAppended, BookReadyToPickup, null} - when the added item
+     *          becomes ready to pick up for the first in the reservations queue and other
+     *          readers still have reservations.
+     *      <li>{@code InventoryAppended, BookReadyToPickup, LoansBecameExtensionAllowed} - when the
+     *          added item becomes ready to pick up for the first in the reservations queue and there aro no
+     *          readers in the queue except him. In that case all recent loans of this book
+     *          become allowed for extension.
      * </ul>
      *
      * @param cmd command with the identifier of a specific item.
@@ -192,12 +191,11 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         if (isBookReservedBySingleUser() && isBookBorrowed()) {
             final LoansBecameExtensionAllowed loansBecameExtensionAllowed
                     = createLoansBecameExtensionAllowedEvent();
-            final Triplet result = Triplet.of(
-                    inventoryAppended, bookReadyToPickup,
-                    loansBecameExtensionAllowed);
+            final Triplet result = Triplet.of(inventoryAppended,
+                                              bookReadyToPickup,
+                                              loansBecameExtensionAllowed);
             return result;
         }
-
         Triplet result = Triplet.withNullable(inventoryAppended, bookReadyToPickup, null);
         return result;
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -758,7 +758,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final Timestamp pickUpDeadline = Timestamp.newBuilder()
                                                   .setSeconds(pickupDeadlineTimeSeconds)
                                                   .build();
-        final InventoryId inventoryId = getState().getInventoryId();
+        final InventoryId inventoryId = cmd.getInventoryId();
         final BookReadyToPickup bookReadyToPickup =
                 BookReadyToPickup.newBuilder()
                                  .setInventoryId(inventoryId)

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -132,11 +132,11 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     private static final int LOAN_PERIOD = 60 * 60 * 24 * 14;
 
     /**
-     * Borrow period.
+     * Borrow period. After this time satisfied reservation becomes expired.
      *
-     * <p>secondsInMinute * minutesInHours * hoursInTwoDays
+     * <p>secondsInMinute * minutesInHours * hoursInDay * twoDays
      */
-    private static final int OPEN_FOR_BORROW_PERIOD = 60 * 60 * 48;
+    private static final int OPEN_FOR_BORROW_PERIOD = 60 * 60 * 24 * 2;
 
     /**
      * Creates a new instance.
@@ -187,8 +187,9 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * @param cmd command to reserve a book.
      * @return a {@code ReservationAdded} event.
-     * @throws BookAlreadyBorrowed if a book is already borrowed by a user.
-     * @throws BookAlreadyReserved if a reservation already exists.
+     * @throws BookAlreadyBorrowed        if a book is already borrowed by a user.
+     * @throws BookAlreadyReserved        if a reservation already exists.
+     * @throws CannotReserveAvailableBook upon an attempt to reserve available book.
      */
     @Assign
     ReservationAdded handle(ReserveBook cmd) throws BookAlreadyBorrowed,
@@ -224,15 +225,15 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *           allowed and book is reserved by a user (this reservation should be satisfied).
      * </ul>
      *
-     * @param cmd command to borrow book.
-     * @return the {@link Pair} of the events.
+     * @param cmd command to borrow the book.
+     * @return the {@link Pair} of events.
      * @throws BookAlreadyBorrowed if a book is already borrowed ba a user.
      * @throws NonAvailableBook in following cases:
      * <ul>
      *      <li>if this item is already borrowed by somebody
      *      <li>user has the reservation for this book and it is not satisfied
      *      <li>user has no reservation for this book but the satisfied reservations count for this
-     *          book is greater or equal the `in library` items count.
+     *          book is greater or equal the `in library` items count(no items free for borrowing).
      * </ul>
      */ 
     // @formatter:on
@@ -250,7 +251,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
             throw nonAvailableBook(cmd);
         }
 
-        final BookBorrowed bookBorrowedEvent = createBookBorrowedEvent(cmd);
         final List<Reservation> reservations = getState().getReservationsList();
 
         if (isBookReservedByUser(userId)) {
@@ -258,6 +258,9 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
             if (!reservation.getIsSatisfied()) {
                 throw nonAvailableBook(cmd);
             }
+            final int availableItemsCount = getAvailableInventoryItemsCount();
+            final BookBorrowed bookBorrowedEvent =
+                    createBookBorrowedEvent(cmd, availableItemsCount);
             final ReservationBecameLoan reservationBecameLoanEvent =
                     createReservationBecameLoanEvent(cmd);
             Pair result = Pair.of(bookBorrowedEvent, reservationBecameLoanEvent);
@@ -267,6 +270,9 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         if (!isThereInventoryItemsFreeForBorrowing()) {
             throw nonAvailableBook(cmd);
         }
+        final int availableItemsCount = getAvailableInventoryItemsCount();
+        final BookBorrowed bookBorrowedEvent =
+                createBookBorrowedEvent(cmd, availableItemsCount - 1);
         final Pair result = Pair.withNullable(bookBorrowedEvent, null);
         return result;
     }
@@ -418,7 +424,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * <p>For details see {@link ForbidLoansExtension}.
      *
-     * @param cmd command to allow loans extension.
+     * @param cmd command to forbid loans extension.
      * @return a {@code LoansExtensionForbidden} event.
      */
     @Assign
@@ -433,7 +439,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * <p>For details see {@link SatisfyReservation}.
      *
-     * @param cmd command to allow loans extension.
+     * @param cmd command to satisfy users reservation.
      * @return a {@code BookReadyToPickup} event.
      */
     @Assign
@@ -447,7 +453,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * <p>For details see {@link MarkBookAsAvailable}.
      *
-     * @param cmd command to allow loans extension.
+     * @param cmd command to make book public available.
      * @return a {@code BookBecameAvailable} event.
      */
     @Assign
@@ -499,9 +505,10 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     @Apply
     void emptyEvent(Empty event) {
         // Applier for empty event.
-        // Used when BorrowBook handler returns two events:
+        //
+        // Used when BorrowBook command handler returns two events:
         // BookBorrowed, Empty
-        // to handle Empty event without changing aggregate state.
+        // Handle Empty event without changing aggregate state.
     }
 
     @Apply
@@ -530,7 +537,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     @Apply
     void bookBecameAvailable(BookBecameAvailable event) {
         // BookBecameAvailable event does not cause aggregate state changes.
-        // Used to notify application read side about free
+        // Used to notify application read side about available items count change
     }
 
     @Apply
@@ -573,32 +580,29 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                     .build();
         final Timestamp whenCreated = event.getWhenCreated();
         final UserId forWhomReserved = event.getForWhomReserved();
-        final Reservation newReservation = Reservation.newBuilder()
-                                                      .setBookId(bookId)
-                                                      .setWhenCreated(whenCreated)
-                                                      .setWhoReserved(forWhomReserved)
-                                                      .setIsSatisfied(false)
-                                                      .build();
-        getBuilder().addReservations(newReservation);
+        final Reservation.Builder reservation = Reservation.newBuilder()
+                                                           .setBookId(bookId)
+                                                           .setWhenCreated(whenCreated)
+                                                           .setWhoReserved(forWhomReserved)
+                                                           .setIsSatisfied(false);
+        if (event.hasWhenExpected()) {
+            final Timestamp whenExpected = event.getWhenExpected();
+            reservation.setWhenExpected(whenExpected);
+        }
+        getBuilder().addReservations(reservation.build());
     }
 
-    /**
-     * Applies a {@code BookBorrowed} event.
-     *
-     * <p>For details see {@link BookBorrowed}.
-     *
-     * @param event a {@code BookBorrowed} event message.
-     */
     @Apply
     void bookBorrowed(BookBorrowed event) {
         final List<InventoryItem> inventoryItems = getBuilder().getInventoryItems();
         final InventoryItemId inventoryItemId = event.getInventoryItemId();
         final int itemPosition = getInventoryItemIndexById(inventoryItemId, inventoryItems);
         final InventoryItem inventoryItem = inventoryItems.get(itemPosition);
+        final UserId whoBorrowed = event.getWhoBorrowed();
         final InventoryItem borrowedItem = InventoryItem.newBuilder(inventoryItem)
                                                         .clearInLibrary()
                                                         .setBorrowed(true)
-                                                        .setUserId(event.getWhoBorrowed())
+                                                        .setUserId(whoBorrowed)
                                                         .build();
         final Timestamp whenBorrowed = event.getWhenBorrowed();
         final Timestamp whenDue = event.getWhenDue();
@@ -607,7 +611,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                               .setLoanId(event.getLoanId())
                               .setInventoryItemId(inventoryItemId)
                               .setStatus(LOAN_RECENT)
-                              .setWhoBorrowed(event.getWhoBorrowed())
+                              .setWhoBorrowed(whoBorrowed)
                               .setWhenTaken(whenBorrowed)
                               .setWhenDue(whenDue)
                               .setIsAllowedExtension(true)
@@ -629,12 +633,12 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         updateLoanStatus(loanId, LOAN_SOULD_RETURN_SOON);
     }
 
-    private void updateLoanStatus(LoanId loanId, LoanStatus loanStatus) {
+    private void updateLoanStatus(LoanId loanId, LoanStatus newLoanStatus) {
         final List<Loan> loans = getBuilder().getLoans();
         final int loanPosition = getLoanIndexByLoanId(loanId, loans);
         final Loan loan = loans.get(loanPosition);
         final Loan updatedLoan = Loan.newBuilder(loan)
-                                     .setStatus(loanStatus)
+                                     .setStatus(newLoanStatus)
                                      .build();
         getBuilder().setLoans(loanPosition, updatedLoan);
     }
@@ -823,10 +827,10 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                                 .setInventoryId(inventoryId)
                                 .setForWhomReserved(userId)
                                 .setWhenCreated(getCurrentTime());
+
         if (readyToPickUpExpectedTime.isPresent()) {
             reservationAddedBuilder.setWhenExpected(readyToPickUpExpectedTime.get());
         }
-
         return reservationAddedBuilder.build();
     }
 
@@ -852,7 +856,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         return loansExtensionForbidden;
     }
 
-    private BookBorrowed createBookBorrowedEvent(BorrowBook cmd) {
+    private BookBorrowed createBookBorrowedEvent(BorrowBook cmd, int availableItemsCount) {
         final InventoryId inventoryId = cmd.getInventoryId();
         final InventoryItemId inventoryItemId = cmd.getInventoryItemId();
         final UserId userId = cmd.getUserId();
@@ -863,9 +867,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final Timestamp whenDue = Timestamp.newBuilder()
                                            .setSeconds(whenBorrowed.getSeconds() + LOAN_PERIOD)
                                            .build();
-        // current available count should be decreased to match its value
-        // after applying this event.
-        final int availableItemsCount = getAvailableInventoryItemsCount() - 1;
         final BookBorrowed bookBorrowed = BookBorrowed.newBuilder()
                                                       .setInventoryId(inventoryId)
                                                       .setInventoryItemId(inventoryItemId)
@@ -1133,16 +1134,17 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * All following cases are provided when the reservation is allowed:
      * <ul>
-     *      <li>if the loans list is empty(book has no items) the expected time cannot be calculated
+     *      <li>if the loans list is empty(book has no items) the expected time cannot be calculated.
+     *          {@code Optional.absent()} is returned.
      *      <li>if there are loans allowed for extension in the list, the expected time equals
-     *          to the first that kind loan due time.
+     *          to the first allowed for extension loan due time.
      *      <li>if there are no loans allowed for extension, the expected time is calculated  as:
      *          lastLoanDueTime + (unsatisfiedReservationsCount - loansCount + 1)*LOAN_PERIOD
      *</ul>
      *
      * @param loans the list of loans
      * @param reservations the list of reservations
-     * @return expected time when the reservation should be satisfied.
+     * @return {@code Optional} expected time when the reservation should be satisfied.
      */
     // @formatter:on
     private Optional<Timestamp> getReadyToPickUpExpectedTime(List<Loan> loans,

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -263,7 +263,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
                     createBookBorrowedEvent(cmd, availableItemsCount);
             final ReservationBecameLoan reservationBecameLoanEvent =
                     createReservationBecameLoanEvent(cmd);
-            Pair result = Pair.of(bookBorrowedEvent, reservationBecameLoanEvent);
+            final Pair result = Pair.of(bookBorrowedEvent, reservationBecameLoanEvent);
             return result;
         }
 
@@ -1024,26 +1024,26 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
 
     private boolean isBookReservedByUser(UserId userId) {
         final List<Reservation> reservations = getState().getReservationsList();
-        final boolean any = Iterables.any(reservations, item -> item.getWhoReserved()
-                                                                    .equals(userId));
-        return any;
+        final boolean isReserved = Iterables.any(reservations, item -> item.getWhoReserved()
+                                                                           .equals(userId));
+        return isReserved;
     }
 
     private boolean isBookBorrowedByUser(UserId userId) {
         final List<Loan> loans = getState().getLoansList();
-        final boolean any = Iterables.any(loans, item -> item.getWhoBorrowed()
-                                                             .equals(userId));
-        return any;
+        final boolean isBorrowed = Iterables.any(loans, item -> item.getWhoBorrowed()
+                                                                    .equals(userId));
+        return isBorrowed;
     }
 
     private boolean isInventoryItemBorrowedByUser(InventoryItemId itemId, UserId userId) {
         final List<InventoryItem> inventoryItems = getState().getInventoryItemsList();
-        final boolean any = Iterables.any(inventoryItems,
-                                          item -> item.getUserId()
-                                                      .equals(userId) &&
-                                                  item.getInventoryItemId()
-                                                      .equals(itemId));
-        return any;
+        final boolean isBorrowed = Iterables.any(inventoryItems,
+                                                 item -> item.getUserId()
+                                                             .equals(userId) &&
+                                                         item.getInventoryItemId()
+                                                             .equals(itemId));
+        return isBorrowed;
     }
 
     private boolean isInventoryItemBorrowed(InventoryItemId itemId) {
@@ -1055,16 +1055,16 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
 
     private boolean inventoryItemExists(InventoryItemId inventoryItemId) {
         final List<InventoryItem> inventoryItems = getState().getInventoryItemsList();
-        final boolean any = Iterables.any(inventoryItems, item -> item.getInventoryItemId()
-                                                                      .equals(inventoryItemId));
-        return any;
+        final boolean exists = Iterables.any(inventoryItems, item -> item.getInventoryItemId()
+                                                                         .equals(inventoryItemId));
+        return exists;
     }
 
     private boolean loanExists(LoanId loanId) {
         final List<Loan> loans = getState().getLoansList();
-        final boolean any = Iterables.any(loans, item -> item.getLoanId()
-                                                             .equals(loanId));
-        return any;
+        final boolean exsists = Iterables.any(loans, item -> item.getLoanId()
+                                                                 .equals(loanId));
+        return exsists;
     }
 
     private Reservation getReservationByUserId(UserId userId, List<Reservation> reservations) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -445,6 +445,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      */
     @Assign
     BookBecameAvailable handle(MarkBookAsAvailable cmd) {
+        System.out.println("in handler");
         final BookBecameAvailable result = createBookBecameAvailableEvent();
         return result;
     }
@@ -948,11 +949,15 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     private ReservationCanceled createReservationCanceledEvent(CancelReservation cmd) {
         final InventoryId inventoryId = cmd.getInventoryId();
         final UserId userId = cmd.getUserId();
+        final List<Reservation> reservations = getState().getReservationsList();
+        final Reservation reservation = getReservationByUserId(userId, reservations);
+        final boolean isSatisfied = reservation.getIsSatisfied();
         final ReservationCanceled reservationCanceledEvent =
                 ReservationCanceled.newBuilder()
                                    .setInventoryId(inventoryId)
                                    .setWhoCanceled(userId)
                                    .setWhenCanceled(getCurrentTime())
+                                   .setWasSatisfied(isSatisfied)
                                    .build();
         return reservationCanceledEvent;
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -87,7 +87,6 @@ import javaclasses.exlibris.c.rejection.CannotWriteBookOff;
 import javaclasses.exlibris.c.rejection.NonAvailableBook;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.spine.time.Time.getCurrentTime;
 import static javaclasses.exlibris.LoanStatus.LOAN_OVERDUE;
@@ -737,9 +736,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
     private BookBecameAvailable createBookBecameAvailableEvent() {
         final InventoryId inventoryId = getState().getInventoryId();
         final Timestamp currentTime = getCurrentTime();
-        // current available count should be increased to match its value
-        // after applying this event.
-        final int availableItemsCount = getAvailableInventoryItemsCount() + 1;
+        final int availableItemsCount = getAvailableInventoryItemsCount();
         final BookBecameAvailable bookBecameAvailable =
                 BookBecameAvailable.newBuilder()
                                    .setInventoryId(inventoryId)
@@ -1079,13 +1076,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         final int index = Iterables.indexOf(inventoryItems, item -> item.getInventoryItemId()
                                                                         .equals(inventoryItemId));
         return index;
-    }
-
-    private List<UserId> getLoanOwners(List<Loan> loans) {
-        final List<UserId> loanOwners = loans.stream()
-                                             .map(Loan::getWhoBorrowed)
-                                             .collect(Collectors.toList());
-        return loanOwners;
     }
 
     private boolean isLoanAllowedForExtension(LoanId loanId) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -242,7 +242,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
 
         final BookBorrowed bookBorrowedEvent = createBookBorrowedEvent(cmd);
         final List<Reservation> reservations = getState().getReservationsList();
-        final List<InventoryItem> inventoryItems = getState().getInventoryItemsList();
 
         if (isBookReservedByUser(userId)) {
             final Reservation reservation = getReservationByUserId(userId, reservations);
@@ -255,7 +254,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
             return result;
         }
 
-        if (!isThereFreeInventoryItems()) {
+        if (!isThereInventoryItemsFreeForBorrowing()) {
             throw nonAvailableBook(cmd);
         }
         final Pair result = Pair.withNullable(bookBorrowedEvent, null);
@@ -299,7 +298,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      * @param cmd command with the identifier of a loan
      *            that a user is going to extend.
      * @return a {@code LoanPeriodExtended} event.
-     * @throws CannotExtendLoanPeriod if a loan period extension isn’t possible.
+     * @throws CannotExtendLoanPeriod if a loan period extension isn’t allowed.
      */
     @Assign
     LoanPeriodExtended handle(ExtendLoanPeriod cmd) throws CannotExtendLoanPeriod {
@@ -318,8 +317,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      *
      * <p>For details see {@link CancelReservation}.
      *
-     * @param cmd command with the identifier of a reservation
-     *            that a user is going to cancel.
+     * @param cmd command with the identifier of a user who is going to cancel a reservation.
      * @return the {@code ReservationCanceled} event.
      * @throws CannotCancelMissingReservation if a reservation is missing.
      */
@@ -1099,7 +1097,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         return isAllowed;
     }
 
-    private boolean isThereFreeInventoryItems() {
+    private boolean isThereInventoryItemsFreeForBorrowing() {
         final List<InventoryItem> inventoryItems = getState().getInventoryItemsList();
         final List<Reservation> reservations = getState().getReservationsList();
         final int freeInventoryItemsCount = getFreeInventoryItemsCount(inventoryItems,

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregate.java
@@ -239,7 +239,7 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
         if (isBookBorrowedByUser(userId)) {
             throw bookAlreadyBorrowed(cmd);
         }
-        if (isInventoryItemBorrowed(inventoryItemId)) {
+        if (inventoryItemExists(inventoryItemId) && isInventoryItemBorrowed(inventoryItemId)) {
             throw nonAvailableBook(cmd);
         }
 
@@ -445,7 +445,6 @@ public class InventoryAggregate extends Aggregate<InventoryId, Inventory, Invent
      */
     @Assign
     BookBecameAvailable handle(MarkBookAsAvailable cmd) {
-        System.out.println("in handler");
         final BookBecameAvailable result = createBookBecameAvailableEvent();
         return result;
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
@@ -30,6 +30,7 @@ import javaclasses.exlibris.c.rejection.BookAlreadyBorrowed;
 import javaclasses.exlibris.c.rejection.BookAlreadyReserved;
 import javaclasses.exlibris.c.rejection.CannotCancelMissingReservation;
 import javaclasses.exlibris.c.rejection.CannotExtendLoanPeriod;
+import javaclasses.exlibris.c.rejection.CannotReserveAvailableBook;
 import javaclasses.exlibris.c.rejection.CannotReturnMissingBook;
 import javaclasses.exlibris.c.rejection.CannotReturnNonBorrowedBook;
 import javaclasses.exlibris.c.rejection.CannotWriteBookOff;
@@ -57,6 +58,7 @@ class InventoryAggregateRejections {
      * <ol>
      * <li> {@link BookAlreadyBorrowed} a rejection when a user tries to reserve a book that he borrowed by himself.</li>
      * <li> {@link BookAlreadyReserved} a rejection when a user tries to reserve a book that he already reserved.</li>
+     * <li> {@link CannotReserveAvailableBook} a rejection when a user tries to reserve a book that is available to borrow.</li>
      * </ol>
      */
     static class ReserveBookRejection {
@@ -77,6 +79,16 @@ class InventoryAggregateRejections {
         static BookAlreadyReserved bookAlreadyReserved(ReserveBook cmd) throws BookAlreadyReserved {
             checkNotNull(cmd);
             throw new BookAlreadyReserved(cmd.getInventoryId(), cmd.getUserId(), getCurrentTime());
+        }
+
+        /**
+         * Throws a rejection when a user tries to reserve a book that is available to borrow.
+         */
+        static CannotReserveAvailableBook cannotReserveAvailableBook(ReserveBook cmd) throws
+                                                                                      CannotReserveAvailableBook {
+            checkNotNull(cmd);
+            throw new CannotReserveAvailableBook(cmd.getInventoryId(), cmd.getUserId(),
+                                                 getCurrentTime());
         }
     }
 

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
@@ -32,7 +32,7 @@ import javaclasses.exlibris.c.rejection.CannotCancelMissingReservation;
 import javaclasses.exlibris.c.rejection.CannotExtendLoanPeriod;
 import javaclasses.exlibris.c.rejection.CannotReturnMissingBook;
 import javaclasses.exlibris.c.rejection.CannotReturnNonBorrowedBook;
-import javaclasses.exlibris.c.rejection.CannotWriteMissingBookOff;
+import javaclasses.exlibris.c.rejection.CannotWriteBookOff;
 import javaclasses.exlibris.c.rejection.NonAvailableBook;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -93,11 +93,11 @@ class InventoryAggregateRejections {
     /**
      * Throws a rejection when a librarian tries to write a missing book off.
      */
-    static CannotWriteMissingBookOff cannotWriteMissingBookOff(WriteBookOff cmd)
-            throws CannotWriteMissingBookOff {
+    static CannotWriteBookOff cannotWriteBookOff(WriteBookOff cmd)
+            throws CannotWriteBookOff {
         checkNotNull(cmd);
-        throw new CannotWriteMissingBookOff(cmd.getInventoryId(), cmd.getLibrarianId(),
-                                            cmd.getInventoryItemId(), getCurrentTime());
+        throw new CannotWriteBookOff(cmd.getInventoryId(), cmd.getLibrarianId(),
+                                     cmd.getInventoryItemId(), getCurrentTime());
     }
 
     /**

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryAggregateRejections.java
@@ -54,7 +54,7 @@ class InventoryAggregateRejections {
     }
 
     /**
-     * Holds 2 rejections:
+     * Holds 3 rejections:
      * <ol>
      * <li> {@link BookAlreadyBorrowed} a rejection when a user tries to reserve a book that he borrowed by himself.</li>
      * <li> {@link BookAlreadyReserved} a rejection when a user tries to reserve a book that he already reserved.</li>
@@ -82,7 +82,7 @@ class InventoryAggregateRejections {
         }
 
         /**
-         * Throws a rejection when a user tries to reserve a book that is available to borrow.
+         * Throws a rejection when a user tries to reserve a book that is available for borrowing.
          */
         static CannotReserveAvailableBook cannotReserveAvailableBook(ReserveBook cmd) throws
                                                                                       CannotReserveAvailableBook {
@@ -103,7 +103,7 @@ class InventoryAggregateRejections {
     }
 
     /**
-     * Throws a rejection when a librarian tries to write a missing book off.
+     * Throws a rejection when a librarian tries to write a missing book off or the book is borrowed.
      */
     static CannotWriteBookOff cannotWriteBookOff(WriteBookOff cmd)
             throws CannotWriteBookOff {
@@ -116,7 +116,8 @@ class InventoryAggregateRejections {
      * Holds two rejections:
      * <ol>
      * <li>{@link CannotReturnNonBorrowedBook} a rejection when a user tries to return a non-borrowed book.</li>
-     * <li>{@link CannotReturnMissingBook} a rejection when a user tries to return the missing {@link javaclasses.exlibris.InventoryItem}.</li>
+     * <li>{@link CannotReturnMissingBook} a rejection when a user tries to return the missing
+     * {@link javaclasses.exlibris.InventoryItem}.</li>
      * </ol>
      */
     static class ReturnBookRejection {
@@ -145,7 +146,7 @@ class InventoryAggregateRejections {
     }
 
     /**
-     * Throws a rejection when a user tries to extend loan period but another user has already reserved book.
+     * Throws a rejection when a user tries to extend loan period but it is not allowed for his loan.
      */
     static CannotExtendLoanPeriod cannotExtendLoanPeriod(ExtendLoanPeriod cmd)
             throws CannotExtendLoanPeriod {

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
@@ -50,14 +50,17 @@ public class InventoryRepository extends AggregateRepository<InventoryId, Invent
         return InventoryRepositorySingleton.INSTANCE.value;
     }
 
+    /**
+     * Sets the new repository instance value to clear storage for tests.
+     */
     @VisibleForTesting
-    public static void clearInstance() {
+    public static void setNewInstance() {
         InventoryRepositorySingleton.INSTANCE.value = new InventoryRepository();
     }
 
     private enum InventoryRepositorySingleton {
         INSTANCE;
-        public InventoryRepository value = new InventoryRepository();
+        private InventoryRepository value = new InventoryRepository();
     }
 
     private InventoryRepository() {

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
@@ -44,7 +44,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
 public class InventoryRepository extends AggregateRepository<InventoryId, InventoryAggregate> {
 
     /**
-     * Returns instance of the VendorRepository
+     * Returns instance of the InventoryRepository
      */
     public static InventoryRepository getRepository() {
         return InventoryRepositorySingleton.INSTANCE.value;
@@ -64,6 +64,7 @@ public class InventoryRepository extends AggregateRepository<InventoryId, Invent
     }
 
     private InventoryRepository() {
+        super();
         getEventRouting().replaceDefault((EventRoute<InventoryId, Message>) (message, context) -> {
             if (message instanceof BookAdded) {
                 return getInventoryIds((BookAdded) message);

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
@@ -20,6 +20,7 @@
 
 package javaclasses.exlibris.c.inventory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import io.spine.server.aggregate.AggregateRepository;
@@ -49,12 +50,17 @@ public class InventoryRepository extends AggregateRepository<InventoryId, Invent
         return InventoryRepositorySingleton.INSTANCE.value;
     }
 
-    private enum InventoryRepositorySingleton {
-        INSTANCE;
-        public final InventoryRepository value = new InventoryRepository();
+    @VisibleForTesting
+    public static void clearInstance() {
+        InventoryRepositorySingleton.INSTANCE.value = new InventoryRepository();
     }
 
-    public InventoryRepository() {
+    private enum InventoryRepositorySingleton {
+        INSTANCE;
+        public InventoryRepository value = new InventoryRepository();
+    }
+
+    private InventoryRepository() {
         getEventRouting().replaceDefault((EventRoute<InventoryId, Message>) (message, context) -> {
             if (message instanceof BookAdded) {
                 return getInventoryIds((BookAdded) message);

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
@@ -42,6 +42,18 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  */
 public class InventoryRepository extends AggregateRepository<InventoryId, InventoryAggregate> {
 
+    /**
+     * Returns instance of the VendorRepository
+     */
+    public static InventoryRepository getRepository() {
+        return InventoryRepositorySingleton.INSTANCE.value;
+    }
+
+    private enum InventoryRepositorySingleton {
+        INSTANCE;
+        public final InventoryRepository value = new InventoryRepository();
+    }
+
     public InventoryRepository() {
         getEventRouting().replaceDefault((EventRoute<InventoryId, Message>) (message, context) -> {
             if (message instanceof BookAdded) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/inventory/InventoryRepository.java
@@ -22,9 +22,8 @@ package javaclasses.exlibris.c.inventory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.Message;
 import io.spine.server.aggregate.AggregateRepository;
-import io.spine.server.route.EventRoute;
+import io.spine.server.route.EventRouting;
 import javaclasses.exlibris.BookId;
 import javaclasses.exlibris.InventoryId;
 import javaclasses.exlibris.c.BookAdded;
@@ -33,7 +32,6 @@ import javaclasses.exlibris.c.BookRemoved;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.of;
-import static io.spine.util.Exceptions.newIllegalArgumentException;
 
 /**
  * Repository for {@link javaclasses.exlibris.Inventory}
@@ -65,15 +63,13 @@ public class InventoryRepository extends AggregateRepository<InventoryId, Invent
 
     private InventoryRepository() {
         super();
-        getEventRouting().replaceDefault((EventRoute<InventoryId, Message>) (message, context) -> {
-            if (message instanceof BookAdded) {
-                return getInventoryIds((BookAdded) message);
-            }
-            if (message instanceof BookRemoved) {
-                return getInventoryIds((BookRemoved) message);
-            }
-            throw newIllegalArgumentException("Cannot route the unreacted event.", message);
-        });
+        setUpEventRouting();
+    }
+
+    private void setUpEventRouting() {
+        final EventRouting<InventoryId> routing = getEventRouting();
+        routing.route(BookAdded.class, (message, context) -> getInventoryIds(message));
+        routing.route(BookRemoved.class, (message, context) -> getInventoryIds(message));
     }
 
     private static Set<InventoryId> getInventoryIds(BookRemoved message) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import io.spine.core.CommandContext;
+import io.spine.core.EventContext;
+import io.spine.core.React;
+import io.spine.server.procman.CommandRouted;
+import io.spine.server.procman.CommandRouter;
+import io.spine.server.procman.ProcessManager;
+import javaclasses.exlibris.InventoryId;
+import javaclasses.exlibris.Loan;
+import javaclasses.exlibris.LoansExtension;
+import javaclasses.exlibris.LoansExtensionId;
+import javaclasses.exlibris.LoansExtensionVBuilder;
+import javaclasses.exlibris.Reservation;
+import javaclasses.exlibris.UserId;
+import javaclasses.exlibris.c.AllowLoansExtension;
+import javaclasses.exlibris.c.BookReadyToPickup;
+import javaclasses.exlibris.c.ForbidLoansExtension;
+import javaclasses.exlibris.c.ReservationAdded;
+import javaclasses.exlibris.c.ReservationCanceled;
+import javaclasses.exlibris.c.inventory.InventoryAggregate;
+import javaclasses.exlibris.c.inventory.InventoryRepository;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, LoansExtension, LoansExtensionVBuilder> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id an ID for the new instance
+     * @throws IllegalArgumentException if the ID type is unsupported
+     */
+    protected LoansExtensionProcman(LoansExtensionId id) {
+        super(id);
+    }
+
+    /**
+     * As long as the {@code ReservationQueueProcman} has no state,
+     * the {@link ReservationQueueProcman} is a singleton.
+     */
+    protected static final LoansExtensionId ID =
+            LoansExtensionId.newBuilder()
+                            .setValue("ReservationQueueSingleton")
+                            .build();
+
+    @React
+    CommandRouted on(ReservationAdded event, EventContext ctx) {
+        final InventoryId inventoryId = event.getInventoryId();
+        final CommandContext commandContext = ctx.getCommandContext();
+        return updateLoansExtensionStateRouter(inventoryId, commandContext);
+    }
+
+    @React
+    CommandRouted on(BookReadyToPickup event, EventContext ctx) {
+        final InventoryId inventoryId = event.getInventoryId();
+        final Optional<InventoryAggregate> inventory = getInventory(inventoryId);
+        final InventoryAggregate inventoryAggregate = inventory.get();
+        final CommandContext commandContext = ctx.getCommandContext();
+        return updateLoansExtensionStateRouter(inventoryId, commandContext);
+    }
+
+    @React
+    CommandRouted on(ReservationCanceled event, EventContext ctx) {
+        final boolean wasSatisfied = event.getWasSatisfied();
+        if (!wasSatisfied) {
+            final InventoryId inventoryId = event.getInventoryId();
+            final CommandContext commandContext = ctx.getCommandContext();
+            return updateLoansExtensionStateRouter(inventoryId, commandContext);
+        }
+        return null;
+    }
+
+    private CommandRouted updateLoansExtensionStateRouter(InventoryId inventoryId,
+                                                          CommandContext commandContext) {
+        final Optional<InventoryAggregate> inventoryOptional = getInventory(inventoryId);
+        if (!inventoryOptional.isPresent()) {
+            final String errorMessage = "The aggregate state for %s identifier not found in the InventoryRepository.";
+            throw new IllegalArgumentException(String.format(errorMessage, inventoryId.getBookId()
+                                                                                      .getIsbn62()));
+        }
+        final InventoryAggregate inventory = inventoryOptional.get();
+        final List<Reservation> reservations = inventory.getState()
+                                                        .getReservationsList();
+        final List<Loan> loans = inventory.getState()
+                                          .getLoansList();
+        final int unsatisfiedReservationsCount = getUnsatisfiedReservationsCount(reservations);
+        final int forbiddenToExtendLoansCount = getForbiddenToExtendLoansCount(loans);
+        final int queueDifference = unsatisfiedReservationsCount - forbiddenToExtendLoansCount;
+
+        if (queueDifference > 0) {
+            final Optional<CommandRouter> routerOptional =
+                    forbidLoansExtensionRouter(inventoryId, commandContext, loans, queueDifference);
+            return routerOptional.isPresent() ? routerOptional.get()
+                                                              .routeAll()
+                                              : null;
+
+        }
+        final Optional<CommandRouter> routerOptional =
+                allowLoansExtensionRouter(inventoryId, commandContext, loans,
+                                          Math.abs(queueDifference));
+        return routerOptional.isPresent() ? routerOptional.get()
+                                                          .routeAll()
+                                          : null;
+    }
+
+    private Optional<CommandRouter> forbidLoansExtensionRouter(InventoryId inventoryId,
+                                                               CommandContext commandContext,
+                                                               List<Loan> loans,
+                                                               int numberToForbid) {
+        final List<Loan> allowedForExtensionLoans = loans.stream()
+                                                         .filter(Loan::getIsAllowedExtension)
+                                                         .collect(Collectors.toList());
+
+        final List<UserId> userIds = allowedForExtensionLoans.stream()
+                                                             .map(Loan::getWhoBorrowed)
+                                                             .collect(Collectors.toList());
+        final Iterator<UserId> iterator = userIds.iterator();
+
+        final List<UserId> resultUserIds = new ArrayList<>();
+        while (iterator.hasNext() && resultUserIds.size() < numberToForbid) {
+            resultUserIds.add(iterator.next());
+        }
+
+        if (!resultUserIds.isEmpty()) {
+            final ForbidLoansExtension forbidLoansExtensionCmd =
+                    ForbidLoansExtension.newBuilder()
+                                        .setInventoryId(inventoryId)
+                                        .addAllBorrowers(resultUserIds)
+                                        .build();
+            final CommandRouter commandRouter =
+                    newRouterFor(forbidLoansExtensionCmd, commandContext)
+                            .add(forbidLoansExtensionCmd);
+            return Optional.of(commandRouter);
+        }
+        return Optional.absent();
+    }
+
+    private Optional<CommandRouter> allowLoansExtensionRouter(InventoryId inventoryId,
+                                                              CommandContext commandContext,
+                                                              List<Loan> loans,
+                                                              int numberToAllow) {
+        final List<Loan> forbiddenForExtensionLoans = loans.stream()
+                                                           .filter(item -> !item.getIsAllowedExtension())
+                                                           .collect(Collectors.toList());
+
+        final List<UserId> userIds = forbiddenForExtensionLoans.stream()
+                                                               .map(Loan::getWhoBorrowed)
+                                                               .collect(Collectors.toList());
+        final List<UserId> reverseUserIds = Lists.reverse(userIds);
+
+        final Iterator<UserId> iterator = reverseUserIds.iterator();
+        final List<UserId> resultUserIds = new ArrayList<>();
+        while (iterator.hasNext() && resultUserIds.size() < numberToAllow) {
+            resultUserIds.add(iterator.next());
+        }
+
+        if (!resultUserIds.isEmpty()) {
+            final AllowLoansExtension allowLoansExtension =
+                    AllowLoansExtension.newBuilder()
+                                       .setInventoryId(inventoryId)
+                                       .addAllBorrowers(resultUserIds)
+                                       .build();
+            final CommandRouter commandRouter =
+                    newRouterFor(allowLoansExtension, commandContext)
+                            .add(allowLoansExtension);
+            return Optional.of(commandRouter);
+        }
+        return Optional.absent();
+    }
+
+    private int getUnsatisfiedReservationsCount(List<Reservation> reservations) {
+        final int unsatisfiedReservationsCount = (int) reservations.stream()
+                                                                   .filter(item -> !item.getIsSatisfied())
+                                                                   .count();
+        return unsatisfiedReservationsCount;
+    }
+
+    private int getForbiddenToExtendLoansCount(List<Loan> loans) {
+        final int forbiddenToExtendLoansCount = (int) loans.stream()
+                                                           .filter(item -> !item.getIsAllowedExtension())
+                                                           .count();
+        return forbiddenToExtendLoansCount;
+    }
+
+    private Optional<InventoryAggregate> getInventory(InventoryId inventoryId) {
+        final InventoryRepository inventoryRepository = InventoryRepository.getRepository();
+        final Optional<InventoryAggregate> inventoryOptional =
+                inventoryRepository.find(inventoryId);
+        return inventoryOptional;
+    }
+}

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
@@ -65,6 +65,7 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
      *
      * @param id an ID for the new instance
      * @throws IllegalArgumentException if the ID type is unsupported
+     * @see LoansExtension for more details.
      */
     protected LoansExtensionProcman(LoansExtensionId id) {
         super(id);
@@ -87,8 +88,8 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
     /**
      * Reacts on {@code ReservationCanceled} event.
      *
-     * <p>Performs action only when the canceled reservation was unsatisfied (in that case available
-     * some loans should be allowed for extension).
+     * <p>Performs action only when the canceled reservation was unsatisfied (in that case some
+     * loans should be allowed for extension).
      *
      * @param event        the {@code ReservationCanceled} event to react on.
      * @param eventContext the event context
@@ -151,9 +152,9 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
      * Creates routed command to forbid extension for as many loans as possible to rich the
      * {@code numberToForbid} count.
      *
-     * @param inventoryId the identifier of the {@code InventoryAggregate}
+     * @param inventoryId    the identifier of the {@code InventoryAggregate}
      * @param commandContext the command context
-     * @param loans the list of loans
+     * @param loans          the list of loans
      * @param numberToForbid the target number to forbid
      * @return the routed command to forbid loans extension
      */
@@ -191,12 +192,12 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
 
     /**
      * Creates routed command to allow extension for as many loans as possible to rich the
-     * {@code numberToAllow} count. Loans extension goes from the end of the loans list.
+     * {@code numberToAllow} count. Loans extension permission goes from the end of the loans list.
      *
-     * @param inventoryId the identifier of the {@code InventoryAggregate}
+     * @param inventoryId    the identifier of the {@code InventoryAggregate}
      * @param commandContext the command context
-     * @param loans the list of loans
-     * @param numberToAllow the target number to allow
+     * @param loans          the list of loans
+     * @param numberToAllow  the target number to allow
      * @return the routed command to allow loans extension
      */
     private Optional<CommandRouter> allowLoansExtensionRouter(InventoryId inventoryId,

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
@@ -60,10 +60,6 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
         super(id);
     }
 
-    /**
-     * As long as the {@code ReservationQueueProcman} has no state,
-     * the {@link ReservationQueueProcman} is a singleton.
-     */
     protected static final LoansExtensionId ID =
             LoansExtensionId.newBuilder()
                             .setValue("ReservationQueueSingleton")

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
@@ -79,8 +79,6 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
     @React
     CommandRouted on(BookReadyToPickup event, EventContext ctx) {
         final InventoryId inventoryId = event.getInventoryId();
-        final Optional<InventoryAggregate> inventory = getInventory(inventoryId);
-        final InventoryAggregate inventoryAggregate = inventory.get();
         final CommandContext commandContext = ctx.getCommandContext();
         return updateLoansExtensionStateRouter(inventoryId, commandContext);
     }
@@ -119,7 +117,6 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
             return routerOptional.isPresent() ? routerOptional.get()
                                                               .routeAll()
                                               : null;
-
         }
         final Optional<CommandRouter> routerOptional =
                 allowLoansExtensionRouter(inventoryId, commandContext, loans,

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcman.java
@@ -51,16 +51,6 @@ import java.util.stream.Collectors;
 public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, LoansExtension, LoansExtensionVBuilder> {
 
     /**
-     * Creates a new instance.
-     *
-     * @param id an ID for the new instance
-     * @throws IllegalArgumentException if the ID type is unsupported
-     */
-    protected LoansExtensionProcman(LoansExtensionId id) {
-        super(id);
-    }
-
-    /**
      * As long as the {@code LoansExtensionProcman} is an {@code InventoryAggregate}
      * service and does not hold model state it is a singleton. All subscribed events
      * are routed to the single instance.
@@ -69,6 +59,16 @@ public class LoansExtensionProcman extends ProcessManager<LoansExtensionId, Loan
             LoansExtensionId.newBuilder()
                             .setValue("ReservationQueueSingleton")
                             .build();
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id an ID for the new instance
+     * @throws IllegalArgumentException if the ID type is unsupported
+     */
+    protected LoansExtensionProcman(LoansExtensionId id) {
+        super(id);
+    }
 
     @React
     CommandRouted on(ReservationAdded event, EventContext eventContext) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcmanRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/LoansExtensionProcmanRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import io.spine.server.procman.ProcessManagerRepository;
+import javaclasses.exlibris.LoansExtension;
+import javaclasses.exlibris.LoansExtensionId;
+
+import static java.util.Collections.singleton;
+import static javaclasses.exlibris.c.procman.LoansExtensionProcman.ID;
+
+public class LoansExtensionProcmanRepository extends ProcessManagerRepository<LoansExtensionId, LoansExtensionProcman, LoansExtension> {
+    public LoansExtensionProcmanRepository() {
+        super();
+        setUpEventRoute();
+    }
+
+    protected void setUpEventRoute() {
+        getEventRouting().replaceDefault(((message, context) -> singleton(ID)));
+    }
+}

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueue.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueue.java
@@ -57,7 +57,7 @@ public class ReservationQueue extends ProcessManager<ReservationQueueId, Empty, 
         super(id);
     }
 
-    public static final ReservationQueueId ID =
+    protected static final ReservationQueueId ID =
             ReservationQueueId.newBuilder()
                               .setValue("ReservationQueueSingleton")
                               .build();

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueue.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueue.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Empty;
+import io.spine.core.CommandContext;
+import io.spine.core.EventContext;
+import io.spine.core.React;
+import io.spine.server.procman.CommandRouted;
+import io.spine.server.procman.CommandRouter;
+import io.spine.server.procman.ProcessManager;
+import io.spine.validate.EmptyVBuilder;
+import javaclasses.exlibris.InventoryId;
+import javaclasses.exlibris.Reservation;
+import javaclasses.exlibris.ReservationQueueId;
+import javaclasses.exlibris.UserId;
+import javaclasses.exlibris.c.BookReturned;
+import javaclasses.exlibris.c.InventoryAppended;
+import javaclasses.exlibris.c.MarkBookAsAvailable;
+import javaclasses.exlibris.c.ReservationCanceled;
+import javaclasses.exlibris.c.ReservationPickUpPeriodExpired;
+import javaclasses.exlibris.c.SatisfyReservation;
+import javaclasses.exlibris.c.inventory.InventoryAggregate;
+import javaclasses.exlibris.c.inventory.InventoryRepository;
+
+import java.util.List;
+
+public class ReservationQueue extends ProcessManager<ReservationQueueId, Empty, EmptyVBuilder> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id an ID for the new instance
+     * @throws IllegalArgumentException if the ID type is unsupported
+     */
+    protected ReservationQueue(ReservationQueueId id) {
+        super(id);
+    }
+
+    public static final ReservationQueueId ID =
+            ReservationQueueId.newBuilder()
+                              .setValue("ReservationQueueSingleton")
+                              .build();
+
+    @React
+    CommandRouted on(BookReturned event, EventContext ctx) {
+        final InventoryId inventoryId = event.getInventoryId();
+        final CommandContext commandContext = ctx.getCommandContext();
+        final CommandRouter commandRouter = markBookAsAvailableOrSatisfyReservation(inventoryId,
+                                                                                    commandContext);
+        return commandRouter.routeAll();
+    }
+
+    @React
+    CommandRouted on(InventoryAppended event, EventContext ctx) {
+        final InventoryId inventoryId = event.getInventoryId();
+        final CommandContext commandContext = ctx.getCommandContext();
+        final CommandRouter commandRouter = markBookAsAvailableOrSatisfyReservation(inventoryId,
+                                                                                    commandContext);
+        return commandRouter.routeAll();
+    }
+
+    @React
+    CommandRouted on(ReservationPickUpPeriodExpired event, EventContext ctx) {
+        final InventoryId inventoryId = event.getInventoryId();
+        final CommandContext commandContext = ctx.getCommandContext();
+        final CommandRouter commandRouter = markBookAsAvailableOrSatisfyReservation(inventoryId,
+                                                                                    commandContext);
+        return commandRouter.routeAll();
+    }
+
+    @React
+    CommandRouted on(ReservationCanceled event, EventContext ctx) {
+        final boolean reservationWasSatisfied = event.getWasSatisfied();
+        if (reservationWasSatisfied) {
+            final InventoryId inventoryId = event.getInventoryId();
+            final CommandContext commandContext = ctx.getCommandContext();
+            final CommandRouter commandRouter = markBookAsAvailableOrSatisfyReservation(inventoryId,
+                                                                                        commandContext);
+            return commandRouter.routeAll();
+        }
+
+        return CommandRouted.getDefaultInstance();
+    }
+
+    private CommandRouter markBookAsAvailableOrSatisfyReservation(InventoryId inventoryId,
+                                                                  CommandContext commandContext) {
+        final Optional<UserId> userIdOptional = findUserToSatisfyReservation(inventoryId);
+        if (userIdOptional.isPresent()) {
+            final UserId userId = userIdOptional.get();
+            final CommandRouter satisfyReservation = createSatisfyReservation(inventoryId,
+                                                                              commandContext,
+                                                                              userId);
+            return satisfyReservation;
+        }
+        final CommandRouter markBookAsAvailable = createMarkBookAsAvailable(inventoryId,
+                                                                            commandContext);
+        return markBookAsAvailable;
+    }
+
+    private CommandRouter createMarkBookAsAvailable(InventoryId inventoryId,
+                                                    CommandContext commandContext) {
+        final MarkBookAsAvailable markBookAsAvailable =
+                MarkBookAsAvailable.newBuilder()
+                                   .setInventoryId(inventoryId)
+                                   .build();
+        return newRouterFor(markBookAsAvailable, commandContext).add(markBookAsAvailable);
+    }
+
+    private CommandRouter createSatisfyReservation(InventoryId inventoryId,
+                                                   CommandContext commandContext,
+                                                   UserId userId) {
+        final SatisfyReservation satisfyReservation = SatisfyReservation.newBuilder()
+                                                                        .setInventoryId(inventoryId)
+                                                                        .setUserId(userId)
+                                                                        .build();
+        return newRouterFor(satisfyReservation, commandContext).add(satisfyReservation);
+    }
+
+    private Optional<InventoryAggregate> getInventory(InventoryId inventoryId) {
+        final InventoryRepository inventoryRepository = InventoryRepository.getRepository();
+
+        final Optional<InventoryAggregate> inventory = inventoryRepository.find(inventoryId);
+
+        return inventory;
+    }
+
+    private Optional<UserId> findUserToSatisfyReservation(InventoryId inventoryId) {
+        final Optional<InventoryAggregate> inventoryOptional = getInventory(inventoryId);
+        final InventoryAggregate inventory = inventoryOptional.get();
+
+        final List<Reservation> reservations = inventory.getState()
+                                                        .getReservationsList();
+        final int index = Iterables.indexOf(reservations, item -> !item.getIsSatisfied());
+
+        if (index != -1) {
+            final Reservation reservationToSatisfy = reservations.get(index);
+            final UserId whoReserved = reservationToSatisfy.getWhoReserved();
+            return Optional.of(whoReserved);
+        }
+        return Optional.absent();
+    }
+}

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
@@ -57,10 +57,6 @@ public class ReservationQueueProcman extends ProcessManager<ReservationQueueId, 
         super(id);
     }
 
-    /**
-     * As long as the {@code ReservationQueueProcman} has no state,
-     * the {@link ReservationQueueProcman} is a singleton.
-     */
     protected static final ReservationQueueId ID =
             ReservationQueueId.newBuilder()
                               .setValue("ReservationQueueSingleton")

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
@@ -48,16 +48,6 @@ import java.util.List;
 public class ReservationQueueProcman extends ProcessManager<ReservationQueueId, ReservationQueue, ReservationQueueVBuilder> {
 
     /**
-     * Creates a new instance.
-     *
-     * @param id an ID for the new instance
-     * @throws IllegalArgumentException if the ID type is unsupported
-     */
-    protected ReservationQueueProcman(ReservationQueueId id) {
-        super(id);
-    }
-
-    /**
      * As long as the {@code ReservationQueueProcman} is an {@code InventoryAggregate}
      * service and does not hold model state it is a singleton. All subscribed events
      * are routed to the single instance.
@@ -66,6 +56,16 @@ public class ReservationQueueProcman extends ProcessManager<ReservationQueueId, 
             ReservationQueueId.newBuilder()
                               .setValue("ReservationQueueSingleton")
                               .build();
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id an ID for the new instance
+     * @throws IllegalArgumentException if the ID type is unsupported
+     */
+    protected ReservationQueueProcman(ReservationQueueId id) {
+        super(id);
+    }
 
     @React
     CommandRouted on(BookReturned event, EventContext eventContext) {

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcman.java
@@ -62,6 +62,7 @@ public class ReservationQueueProcman extends ProcessManager<ReservationQueueId, 
      *
      * @param id an ID for the new instance
      * @throws IllegalArgumentException if the ID type is unsupported
+     * @see ReservationQueue for more details.
      */
     protected ReservationQueueProcman(ReservationQueueId id) {
         super(id);
@@ -98,7 +99,7 @@ public class ReservationQueueProcman extends ProcessManager<ReservationQueueId, 
      * Reacts on {@code ReservationCanceled} event.
      *
      * <p>Performs action only when the canceled reservation was satisfied (in that case available
-     * books count changes).
+     * books count has changed).
      *
      * @param event        the {@code ReservationCanceled} event to react on.
      * @param eventContext the event context

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanRepository.java
@@ -20,16 +20,16 @@
 
 package javaclasses.exlibris.c.procman;
 
-import com.google.protobuf.Empty;
 import io.spine.server.procman.ProcessManagerRepository;
+import javaclasses.exlibris.ReservationQueue;
 import javaclasses.exlibris.ReservationQueueId;
 
 import static java.util.Collections.singleton;
-import static javaclasses.exlibris.c.procman.ReservationQueue.ID;
+import static javaclasses.exlibris.c.procman.ReservationQueueProcman.ID;
 
-public class ReservationQueueRepository extends ProcessManagerRepository<ReservationQueueId, ReservationQueue, Empty> {
+public class ReservationQueueProcmanRepository extends ProcessManagerRepository<ReservationQueueId, ReservationQueueProcman, ReservationQueue> {
 
-    public ReservationQueueRepository() {
+    public ReservationQueueProcmanRepository() {
         super();
         setUpEventRoute();
     }

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueRepository.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/ReservationQueueRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import com.google.protobuf.Empty;
+import io.spine.server.procman.ProcessManagerRepository;
+import javaclasses.exlibris.ReservationQueueId;
+
+import static java.util.Collections.singleton;
+import static javaclasses.exlibris.c.procman.ReservationQueue.ID;
+
+public class ReservationQueueRepository extends ProcessManagerRepository<ReservationQueueId, ReservationQueue, Empty> {
+
+    public ReservationQueueRepository() {
+        super();
+        setUpEventRoute();
+    }
+
+    protected void setUpEventRoute() {
+        getEventRouting().replaceDefault(((message, context) -> singleton(ID)));
+    }
+}

--- a/api-java/src/main/java/javaclasses/exlibris/c/procman/package-info.java
+++ b/api-java/src/main/java/javaclasses/exlibris/c/procman/package-info.java
@@ -18,10 +18,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// @formatter:off
 /**
- * This package contains both book, inventory aggregates, its rejections and process managers.
+ * This package provides implementation for following classes:
+ *
+ * <ul>
+ *     <li>{@code ReservationQueueProcman}
+ *     <li>{@code ReservationQueueProcmanRepository}
+ *     <li>{@code LoansExtensionProcman}
+ *     <li>{@code LoansExtensionProcmanRepository}
+ * </ul>
  */
+// @formatter:on
 @ParametersAreNonnullByDefault
-package javaclasses.exlibris.c;
+package javaclasses.exlibris.c.procman;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -136,7 +136,7 @@ public class FlowTest extends InventoryCommandTest<Message> {
     @BeforeEach
     public void setUp() {
         super.setUp();
-        InventoryRepository.clearInstance();
+        InventoryRepository.setNewInstance();
     }
 
     @Test

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -79,8 +79,7 @@ public class FlowTest extends InventoryCommandTest<Message> {
     private final Command appendInventory2 = requestFactory.createCommand(
             toMessage(appendInventoryInstance(InventoryCommandFactory.inventoryId,
                                               InventoryCommandFactory.inventoryItemId2,
-                                              InventoryCommandFactory.userId,
-                                              InventoryCommandFactory.rfid)));
+                                              InventoryCommandFactory.userId)));
 
     private final Command borrowBook = requestFactory.createCommand(
             toMessage(borrowBookInstance()));

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -1,300 +1,300 @@
-/*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
- *
- * Redistribution and use in source and/or binary forms, with or without
- * modification, must retain the above copyright notice and the following
- * disclaimer.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-package javaclasses.exlibris.c.integrational;
-
-import com.google.protobuf.Message;
-import io.grpc.stub.StreamObserver;
-import io.spine.client.TestActorRequestFactory;
-import io.spine.core.Ack;
-import io.spine.core.Command;
-import io.spine.grpc.StreamObservers;
-import io.spine.server.BoundedContext;
-import io.spine.server.commandbus.CommandBus;
-import javaclasses.exlibris.BookDetailsChange;
-import javaclasses.exlibris.BoundedContexts;
-import javaclasses.exlibris.c.RemoveBook;
-import javaclasses.exlibris.c.inventory.InventoryCommandTest;
-import javaclasses.exlibris.testdata.BookCommandFactory;
-import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
-import javaclasses.exlibris.testdata.InventoryCommandFactory;
-import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import static io.spine.protobuf.TypeConverter.toMessage;
-import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-import static javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
-import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.writeBookOffInstance;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-/**
- * @author Alexander Karpets
- * @author Paul Ageyev
- */
-public class FlowTest extends InventoryCommandTest<Message> {
-
-    private final TestActorRequestFactory requestFactory =
-            TestActorRequestFactory.newInstance(getClass());
-
-    private final BookDetailsChange newBookDetails = BookDetailsChange.newBuilder()
-                                                                      .setNewBookDetails(
-                                                                              BookCommandFactory.bookDetails2)
-                                                                      .build();
-
-    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
-
-    private final Command updateBook = requestFactory.createCommand(
-            toMessage(updateBookInstance(BookCommandFactory.bookId,
-                                         BookCommandFactory.userId2,
-                                         newBookDetails)));
-    private final Command appendInventory = requestFactory.createCommand(
-            toMessage(appendInventoryInstance()));
-
-    private final Command appendInventory2 = requestFactory.createCommand(
-            toMessage(appendInventoryInstance(InventoryCommandFactory.inventoryId,
-                                              InventoryCommandFactory.inventoryItemId2,
-                                              InventoryCommandFactory.userId)));
-
-    private final Command borrowBook = requestFactory.createCommand(
-            toMessage(borrowBookInstance()));
-
-    private final Command borrowBook2 = requestFactory.createCommand(
-            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
-                                         InventoryCommandFactory.inventoryItemId,
-                                         InventoryCommandFactory.userId2)));
-
-    private final Command borrowBook3 = requestFactory.createCommand(
-            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
-                                         InventoryCommandFactory.inventoryItemId2,
-                                         InventoryCommandFactory.userId2)));
-
-    private final Command reserveBook = requestFactory.createCommand(
-            toMessage(reserveBookInstance(InventoryCommandFactory.userId,
-                                          InventoryCommandFactory.inventoryId)));
-
-    private final Command reserveBook2 = requestFactory.createCommand(
-            toMessage(reserveBookInstance(InventoryCommandFactory.userId2,
-                                          InventoryCommandFactory.inventoryId)));
-
-    private final Command returnBook = requestFactory.createCommand(
-            toMessage(returnBookInstance()));
-
-    private final Command returnBook2 = requestFactory.createCommand(
-            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
-                                         InventoryCommandFactory.inventoryItemId,
-                                         InventoryCommandFactory.userId2)));
-
-    private final Command returnBook3 = requestFactory.createCommand(
-            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
-                                         InventoryCommandFactory.inventoryItemId2,
-                                         InventoryCommandFactory.userId2)));
-
-    private final Command writeBookOff = requestFactory.createCommand(
-            toMessage(writeBookOffInstance()));
-
-    private final Command removeBook = requestFactory.createCommand(
-            toMessage(removeBookInstance(BookCommandFactory.bookId,
-                                         BookCommandFactory.librarianId,
-                                         RemoveBook.BookRemovalReasonCase.OUTDATED)));
-
-    private final Command extendLoanPeriod = requestFactory.createCommand(
-            toMessage(extendLoanPeriodInstance()));
-
-    private final Command extendLoanPeriod2 = requestFactory.createCommand(
-            toMessage(extendLoanPeriodInstance(InventoryCommandFactory.inventoryId,
-                                               InventoryCommandFactory.loan.getLoanId(),
-                                               InventoryCommandFactory.userId2)));
-
-    @Override
-    @BeforeEach
-    public void setUp() {
-        super.setUp();
-    }
-
-    @Test
-    @DisplayName("librarian adds book, updates it, appends inventory. User borrows book, returns it, same action do second user, but previously reserved it")
-    void useCase() {
-        final BoundedContext boundedContext = BoundedContexts.create();
-        final CommandBus commandBus = boundedContext.getCommandBus();
-        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-        boundedContext.getRejectionBus()
-                      .register(bookRejectionsSubscriber);
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-        commandBus.post(addBook, observer);
-        commandBus.post(updateBook, observer);
-        commandBus.post(appendInventory, observer);
-        commandBus.post(borrowBook, observer);
-        commandBus.post(reserveBook2, observer);
-        commandBus.post(returnBook, observer);
-        commandBus.post(borrowBook2, observer);
-        commandBus.post(returnBook2, observer);
-        assertFalse(bookRejectionsSubscriber.wasCalled());
-        assertFalse(inventoryRejectionsSubscriber.wasCalled());
-    }
-
-    @Test
-    @DisplayName("librarian adds book, appends inventory. " +
-            "Users borrow books, one user lost the book and the book is written off, another user returns the book.")
-    void secondUseCase() {
-        final BoundedContext boundedContext = BoundedContexts.create();
-        final CommandBus commandBus = boundedContext.getCommandBus();
-
-        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-
-        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-
-        boundedContext.getRejectionBus()
-                      .register(bookRejectionsSubscriber);
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-
-        commandBus.post(addBook, observer);
-
-        commandBus.post(appendInventory, observer);
-        commandBus.post(appendInventory2, observer);
-
-        commandBus.post(borrowBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(borrowBook3, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(reserveBook, observer);
-        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-        InventoryRejectionsSubscriber.clear();
-
-        commandBus.post(extendLoanPeriod, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(returnBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(borrowBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(writeBookOff, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(returnBook3, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(appendInventory, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(borrowBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(returnBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-    }
-
-    @Test
-    @DisplayName("attempt to update, borrow, return missing book leads to rejection, same actions are allowed when book is added.")
-    void rejectionsThrow() {
-        final BoundedContext boundedContext = BoundedContexts.create();
-        final CommandBus commandBus = boundedContext.getCommandBus();
-        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-        boundedContext.getRejectionBus()
-                      .register(bookRejectionsSubscriber);
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-
-        commandBus.post(borrowBook, observer);
-        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-        InventoryRejectionsSubscriber.clear();
-
-        commandBus.post(updateBook, observer);
-        assertTrue(BookRejectionsSubscriber.wasCalled());
-        BookRejectionsSubscriber.clear();
-
-        commandBus.post(addBook, observer);
-        assertFalse(BookRejectionsSubscriber.wasCalled());
-
-        commandBus.post(returnBook, observer);
-        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-        InventoryRejectionsSubscriber.clear();
-
-        commandBus.post(appendInventory, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(updateBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-
-        commandBus.post(borrowBook, observer);
-        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-    }
-
-    @Test
-    @DisplayName("two users by turns borrow book and few times extend their loan periods")
-    void loanFlow() {
-        final BoundedContext boundedContext = BoundedContexts.create();
-        final CommandBus commandBus = boundedContext.getCommandBus();
-        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-        commandBus.post(addBook, observer);
-        commandBus.post(appendInventory, observer);
-        commandBus.post(borrowBook, observer);
-        commandBus.post(extendLoanPeriod, observer);
-        commandBus.post(extendLoanPeriod, observer);
-        commandBus.post(returnBook, observer);
-        commandBus.post(borrowBook2, observer);
-        commandBus.post(extendLoanPeriod2, observer);
-        commandBus.post(extendLoanPeriod2, observer);
-        commandBus.post(returnBook2, observer);
-        assertFalse(inventoryRejectionsSubscriber.wasCalled());
-    }
-
-    @Test
-    @DisplayName("rejection when user to tries extend loan period without taking a book")
-    void extendLoan() {
-        final BoundedContext boundedContext = BoundedContexts.create();
-        final CommandBus commandBus = boundedContext.getCommandBus();
-        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-        commandBus.post(addBook, observer);
-        commandBus.post(appendInventory, observer);
-
-        commandBus.post(borrowBook, observer);
-        commandBus.post(extendLoanPeriod2, observer);
-        assertTrue(inventoryRejectionsSubscriber.wasCalled());
-        InventoryRejectionsSubscriber.clear();
-    }
-}
+///*
+// * Copyright 2018, TeamDev Ltd. All rights reserved.
+// *
+// * Redistribution and use in source and/or binary forms, with or without
+// * modification, must retain the above copyright notice and the following
+// * disclaimer.
+// *
+// * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// */
+//
+//package javaclasses.exlibris.c.integrational;
+//
+//import com.google.protobuf.Message;
+//import io.grpc.stub.StreamObserver;
+//import io.spine.client.TestActorRequestFactory;
+//import io.spine.core.Ack;
+//import io.spine.core.Command;
+//import io.spine.grpc.StreamObservers;
+//import io.spine.server.BoundedContext;
+//import io.spine.server.commandbus.CommandBus;
+//import javaclasses.exlibris.BookDetailsChange;
+//import javaclasses.exlibris.BoundedContexts;
+//import javaclasses.exlibris.c.RemoveBook;
+//import javaclasses.exlibris.c.inventory.InventoryCommandTest;
+//import javaclasses.exlibris.testdata.BookCommandFactory;
+//import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
+//import javaclasses.exlibris.testdata.InventoryCommandFactory;
+//import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//
+//import static io.spine.protobuf.TypeConverter.toMessage;
+//import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+//import static javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
+//import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
+//import static javaclasses.exlibris.testdata.InventoryCommandFactory.writeBookOffInstance;
+//import static org.junit.jupiter.api.Assertions.assertFalse;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//
+///**
+// * @author Alexander Karpets
+// * @author Paul Ageyev
+// */
+//public class FlowTest extends InventoryCommandTest<Message> {
+//
+//    private final TestActorRequestFactory requestFactory =
+//            TestActorRequestFactory.newInstance(getClass());
+//
+//    private final BookDetailsChange newBookDetails = BookDetailsChange.newBuilder()
+//                                                                      .setNewBookDetails(
+//                                                                              BookCommandFactory.bookDetails2)
+//                                                                      .build();
+//
+//    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
+//
+//    private final Command updateBook = requestFactory.createCommand(
+//            toMessage(updateBookInstance(BookCommandFactory.bookId,
+//                                         BookCommandFactory.userId2,
+//                                         newBookDetails)));
+//    private final Command appendInventory = requestFactory.createCommand(
+//            toMessage(appendInventoryInstance()));
+//
+//    private final Command appendInventory2 = requestFactory.createCommand(
+//            toMessage(appendInventoryInstance(InventoryCommandFactory.inventoryId,
+//                                              InventoryCommandFactory.inventoryItemId2,
+//                                              InventoryCommandFactory.userId)));
+//
+//    private final Command borrowBook = requestFactory.createCommand(
+//            toMessage(borrowBookInstance()));
+//
+//    private final Command borrowBook2 = requestFactory.createCommand(
+//            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
+//                                         InventoryCommandFactory.inventoryItemId,
+//                                         InventoryCommandFactory.userId2)));
+//
+//    private final Command borrowBook3 = requestFactory.createCommand(
+//            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
+//                                         InventoryCommandFactory.inventoryItemId2,
+//                                         InventoryCommandFactory.userId2)));
+//
+//    private final Command reserveBook = requestFactory.createCommand(
+//            toMessage(reserveBookInstance(InventoryCommandFactory.userId,
+//                                          InventoryCommandFactory.inventoryId)));
+//
+//    private final Command reserveBook2 = requestFactory.createCommand(
+//            toMessage(reserveBookInstance(InventoryCommandFactory.userId2,
+//                                          InventoryCommandFactory.inventoryId)));
+//
+//    private final Command returnBook = requestFactory.createCommand(
+//            toMessage(returnBookInstance()));
+//
+//    private final Command returnBook2 = requestFactory.createCommand(
+//            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
+//                                         InventoryCommandFactory.inventoryItemId,
+//                                         InventoryCommandFactory.userId2)));
+//
+//    private final Command returnBook3 = requestFactory.createCommand(
+//            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
+//                                         InventoryCommandFactory.inventoryItemId2,
+//                                         InventoryCommandFactory.userId2)));
+//
+//    private final Command writeBookOff = requestFactory.createCommand(
+//            toMessage(writeBookOffInstance()));
+//
+//    private final Command removeBook = requestFactory.createCommand(
+//            toMessage(removeBookInstance(BookCommandFactory.bookId,
+//                                         BookCommandFactory.librarianId,
+//                                         RemoveBook.BookRemovalReasonCase.OUTDATED)));
+//
+//    private final Command extendLoanPeriod = requestFactory.createCommand(
+//            toMessage(extendLoanPeriodInstance()));
+//
+//    private final Command extendLoanPeriod2 = requestFactory.createCommand(
+//            toMessage(extendLoanPeriodInstance(InventoryCommandFactory.inventoryId,
+//                                               InventoryCommandFactory.loan.getLoanId(),
+//                                               InventoryCommandFactory.userId2)));
+//
+//    @Override
+//    @BeforeEach
+//    public void setUp() {
+//        super.setUp();
+//    }
+//
+//    @Test
+//    @DisplayName("librarian adds book, updates it, appends inventory. User borrows book, returns it, same action do second user, but previously reserved it")
+//    void useCase() {
+//        final BoundedContext boundedContext = BoundedContexts.create();
+//        final CommandBus commandBus = boundedContext.getCommandBus();
+//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+//        boundedContext.getRejectionBus()
+//                      .register(bookRejectionsSubscriber);
+//        boundedContext.getRejectionBus()
+//                      .register(inventoryRejectionsSubscriber);
+//        commandBus.post(addBook, observer);
+//        commandBus.post(updateBook, observer);
+//        commandBus.post(appendInventory, observer);
+//        commandBus.post(borrowBook, observer);
+//        commandBus.post(reserveBook2, observer);
+//        commandBus.post(returnBook, observer);
+//        commandBus.post(borrowBook2, observer);
+//        commandBus.post(returnBook2, observer);
+//        assertFalse(bookRejectionsSubscriber.wasCalled());
+//        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+//    }
+//
+//    @Test
+//    @DisplayName("librarian adds book, appends inventory. " +
+//            "Users borrow books, one user lost the book and the book is written off, another user returns the book.")
+//    void secondUseCase() {
+//        final BoundedContext boundedContext = BoundedContexts.create();
+//        final CommandBus commandBus = boundedContext.getCommandBus();
+//
+//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+//
+//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+//
+//        boundedContext.getRejectionBus()
+//                      .register(bookRejectionsSubscriber);
+//        boundedContext.getRejectionBus()
+//                      .register(inventoryRejectionsSubscriber);
+//
+//        commandBus.post(addBook, observer);
+//
+//        commandBus.post(appendInventory, observer);
+//        commandBus.post(appendInventory2, observer);
+//
+//        commandBus.post(borrowBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(borrowBook3, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(reserveBook, observer);
+//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+//        InventoryRejectionsSubscriber.clear();
+//
+//        commandBus.post(extendLoanPeriod, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(returnBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(borrowBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(writeBookOff, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(returnBook3, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(appendInventory, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(borrowBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(returnBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//    }
+//
+//    @Test
+//    @DisplayName("attempt to update, borrow, return missing book leads to rejection, same actions are allowed when book is added.")
+//    void rejectionsThrow() {
+//        final BoundedContext boundedContext = BoundedContexts.create();
+//        final CommandBus commandBus = boundedContext.getCommandBus();
+//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+//        boundedContext.getRejectionBus()
+//                      .register(bookRejectionsSubscriber);
+//        boundedContext.getRejectionBus()
+//                      .register(inventoryRejectionsSubscriber);
+//
+//        commandBus.post(borrowBook, observer);
+//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+//        InventoryRejectionsSubscriber.clear();
+//
+//        commandBus.post(updateBook, observer);
+//        assertTrue(BookRejectionsSubscriber.wasCalled());
+//        BookRejectionsSubscriber.clear();
+//
+//        commandBus.post(addBook, observer);
+//        assertFalse(BookRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(returnBook, observer);
+//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+//        InventoryRejectionsSubscriber.clear();
+//
+//        commandBus.post(appendInventory, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(updateBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//
+//        commandBus.post(borrowBook, observer);
+//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+//    }
+//
+//    @Test
+//    @DisplayName("two users by turns borrow book and few times extend their loan periods")
+//    void loanFlow() {
+//        final BoundedContext boundedContext = BoundedContexts.create();
+//        final CommandBus commandBus = boundedContext.getCommandBus();
+//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+//
+//        boundedContext.getRejectionBus()
+//                      .register(inventoryRejectionsSubscriber);
+//        commandBus.post(addBook, observer);
+//        commandBus.post(appendInventory, observer);
+//        commandBus.post(borrowBook, observer);
+//        commandBus.post(extendLoanPeriod, observer);
+//        commandBus.post(extendLoanPeriod, observer);
+//        commandBus.post(returnBook, observer);
+//        commandBus.post(borrowBook2, observer);
+//        commandBus.post(extendLoanPeriod2, observer);
+//        commandBus.post(extendLoanPeriod2, observer);
+//        commandBus.post(returnBook2, observer);
+//        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+//    }
+//
+//    @Test
+//    @DisplayName("rejection when user to tries extend loan period without taking a book")
+//    void extendLoan() {
+//        final BoundedContext boundedContext = BoundedContexts.create();
+//        final CommandBus commandBus = boundedContext.getCommandBus();
+//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+//
+//        boundedContext.getRejectionBus()
+//                      .register(inventoryRejectionsSubscriber);
+//        commandBus.post(addBook, observer);
+//        commandBus.post(appendInventory, observer);
+//
+//        commandBus.post(borrowBook, observer);
+//        commandBus.post(extendLoanPeriod2, observer);
+//        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+//        InventoryRejectionsSubscriber.clear();
+//    }
+//}

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -164,6 +164,27 @@ public class FlowTest extends InventoryCommandTest<Message> {
     }
 
     @Test
+    @DisplayName("fsdsw")
+    void reservationsTests() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+        commandBus.post(appendInventory, observer);
+        commandBus.post(appendInventory2, observer);
+        commandBus.post(reserveBook2, observer);
+
+        assertFalse(bookRejectionsSubscriber.wasCalled());
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
     @DisplayName("attempt to update, borrow, return missing book leads to rejection, same actions are allowed when book is added.")
     void rejectionsThrow() {
         final BoundedContext boundedContext = BoundedContexts.create();

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -20,6 +20,7 @@
 
 package javaclasses.exlibris.c.integrational;
 
+import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.spine.client.TestActorRequestFactory;
@@ -30,7 +31,9 @@ import io.spine.server.BoundedContext;
 import io.spine.server.commandbus.CommandBus;
 import javaclasses.exlibris.BookDetailsChange;
 import javaclasses.exlibris.BoundedContexts;
+import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.RemoveBook;
+import javaclasses.exlibris.c.inventory.InventoryAggregate;
 import javaclasses.exlibris.c.inventory.InventoryCommandTest;
 import javaclasses.exlibris.c.inventory.InventoryRepository;
 import javaclasses.exlibris.testdata.BookCommandFactory;
@@ -48,6 +51,7 @@ import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstanc
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.writeBookOffInstance;
@@ -95,8 +99,8 @@ public class FlowTest extends InventoryCommandTest<Message> {
                                          InventoryCommandFactory.inventoryItemId2,
                                          InventoryCommandFactory.userId2)));
 
-    private final Command reserveBook = requestFactory.createCommand(
-            toMessage(reserveBookInstance(InventoryCommandFactory.userId,
+    private final Command reserveBook3 = requestFactory.createCommand(
+            toMessage(reserveBookInstance(InventoryCommandFactory.userId3,
                                           InventoryCommandFactory.inventoryId)));
 
     private final Command reserveBook2 = requestFactory.createCommand(
@@ -164,7 +168,7 @@ public class FlowTest extends InventoryCommandTest<Message> {
     }
 
     @Test
-    @DisplayName("fsdsw")
+    @DisplayName("User1 borrows book -> User2 borrows book -> User3 reserves book -> User2 returns book -> User1 loan becomes allowed for extension, reservation satisfied.")
     void reservationsTests() {
         final BoundedContext boundedContext = BoundedContexts.create();
         final CommandBus commandBus = boundedContext.getCommandBus();
@@ -178,7 +182,26 @@ public class FlowTest extends InventoryCommandTest<Message> {
         commandBus.post(addBook, observer);
         commandBus.post(appendInventory, observer);
         commandBus.post(appendInventory2, observer);
-        commandBus.post(reserveBook2, observer);
+        commandBus.post(borrowBook, observer);
+        commandBus.post(borrowBook3, observer);
+        commandBus.post(reserveBook3, observer);
+        final boolean isAllowedExtensionForFirstUser = getAggregateState().getLoans(0)
+                                                                          .getIsAllowedExtension();
+        final boolean isAllowedExtensionForSecondUser = getAggregateState().getLoans(1)
+                                                                           .getIsAllowedExtension();
+        final boolean isSatisfiedBefore = getAggregateState().getReservations(0)
+                                                             .getIsSatisfied();
+        assertFalse(isAllowedExtensionForFirstUser);
+        assertTrue(isAllowedExtensionForSecondUser);
+        assertFalse(isSatisfiedBefore);
+
+        commandBus.post(returnBook3, observer);
+        final boolean isSatisfiedAfter = getAggregateState().getReservations(0)
+                                                            .getIsSatisfied();
+        final boolean isAllowedExtensionForFirstUserAfter = getAggregateState().getLoans(0)
+                                                                               .getIsAllowedExtension();
+        assertTrue(isSatisfiedAfter);
+        assertTrue(isAllowedExtensionForFirstUserAfter);
 
         assertFalse(bookRejectionsSubscriber.wasCalled());
         assertFalse(inventoryRejectionsSubscriber.wasCalled());
@@ -237,5 +260,12 @@ public class FlowTest extends InventoryCommandTest<Message> {
         commandBus.post(borrowBook, observer);
         commandBus.post(extendLoanPeriod, observer);
         assertTrue(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    private Inventory getAggregateState() {
+        final Optional<InventoryAggregate> aggregateOptional = InventoryRepository.getRepository()
+                                                                                  .find(inventoryId);
+        return aggregateOptional.isPresent() ? aggregateOptional.get()
+                                                                .getState() : null;
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/FlowTest.java
@@ -1,300 +1,300 @@
-///*
-// * Copyright 2018, TeamDev Ltd. All rights reserved.
-// *
-// * Redistribution and use in source and/or binary forms, with or without
-// * modification, must retain the above copyright notice and the following
-// * disclaimer.
-// *
-// * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// */
-//
-//package javaclasses.exlibris.c.integrational;
-//
-//import com.google.protobuf.Message;
-//import io.grpc.stub.StreamObserver;
-//import io.spine.client.TestActorRequestFactory;
-//import io.spine.core.Ack;
-//import io.spine.core.Command;
-//import io.spine.grpc.StreamObservers;
-//import io.spine.server.BoundedContext;
-//import io.spine.server.commandbus.CommandBus;
-//import javaclasses.exlibris.BookDetailsChange;
-//import javaclasses.exlibris.BoundedContexts;
-//import javaclasses.exlibris.c.RemoveBook;
-//import javaclasses.exlibris.c.inventory.InventoryCommandTest;
-//import javaclasses.exlibris.testdata.BookCommandFactory;
-//import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
-//import javaclasses.exlibris.testdata.InventoryCommandFactory;
-//import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//import static io.spine.protobuf.TypeConverter.toMessage;
-//import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-//import static javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
-//import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
-//import static javaclasses.exlibris.testdata.InventoryCommandFactory.writeBookOffInstance;
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//
-///**
-// * @author Alexander Karpets
-// * @author Paul Ageyev
-// */
-//public class FlowTest extends InventoryCommandTest<Message> {
-//
-//    private final TestActorRequestFactory requestFactory =
-//            TestActorRequestFactory.newInstance(getClass());
-//
-//    private final BookDetailsChange newBookDetails = BookDetailsChange.newBuilder()
-//                                                                      .setNewBookDetails(
-//                                                                              BookCommandFactory.bookDetails2)
-//                                                                      .build();
-//
-//    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
-//
-//    private final Command updateBook = requestFactory.createCommand(
-//            toMessage(updateBookInstance(BookCommandFactory.bookId,
-//                                         BookCommandFactory.userId2,
-//                                         newBookDetails)));
-//    private final Command appendInventory = requestFactory.createCommand(
-//            toMessage(appendInventoryInstance()));
-//
-//    private final Command appendInventory2 = requestFactory.createCommand(
-//            toMessage(appendInventoryInstance(InventoryCommandFactory.inventoryId,
-//                                              InventoryCommandFactory.inventoryItemId2,
-//                                              InventoryCommandFactory.userId)));
-//
-//    private final Command borrowBook = requestFactory.createCommand(
-//            toMessage(borrowBookInstance()));
-//
-//    private final Command borrowBook2 = requestFactory.createCommand(
-//            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
-//                                         InventoryCommandFactory.inventoryItemId,
-//                                         InventoryCommandFactory.userId2)));
-//
-//    private final Command borrowBook3 = requestFactory.createCommand(
-//            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
-//                                         InventoryCommandFactory.inventoryItemId2,
-//                                         InventoryCommandFactory.userId2)));
-//
-//    private final Command reserveBook = requestFactory.createCommand(
-//            toMessage(reserveBookInstance(InventoryCommandFactory.userId,
-//                                          InventoryCommandFactory.inventoryId)));
-//
-//    private final Command reserveBook2 = requestFactory.createCommand(
-//            toMessage(reserveBookInstance(InventoryCommandFactory.userId2,
-//                                          InventoryCommandFactory.inventoryId)));
-//
-//    private final Command returnBook = requestFactory.createCommand(
-//            toMessage(returnBookInstance()));
-//
-//    private final Command returnBook2 = requestFactory.createCommand(
-//            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
-//                                         InventoryCommandFactory.inventoryItemId,
-//                                         InventoryCommandFactory.userId2)));
-//
-//    private final Command returnBook3 = requestFactory.createCommand(
-//            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
-//                                         InventoryCommandFactory.inventoryItemId2,
-//                                         InventoryCommandFactory.userId2)));
-//
-//    private final Command writeBookOff = requestFactory.createCommand(
-//            toMessage(writeBookOffInstance()));
-//
-//    private final Command removeBook = requestFactory.createCommand(
-//            toMessage(removeBookInstance(BookCommandFactory.bookId,
-//                                         BookCommandFactory.librarianId,
-//                                         RemoveBook.BookRemovalReasonCase.OUTDATED)));
-//
-//    private final Command extendLoanPeriod = requestFactory.createCommand(
-//            toMessage(extendLoanPeriodInstance()));
-//
-//    private final Command extendLoanPeriod2 = requestFactory.createCommand(
-//            toMessage(extendLoanPeriodInstance(InventoryCommandFactory.inventoryId,
-//                                               InventoryCommandFactory.loan.getLoanId(),
-//                                               InventoryCommandFactory.userId2)));
-//
-//    @Override
-//    @BeforeEach
-//    public void setUp() {
-//        super.setUp();
-//    }
-//
-//    @Test
-//    @DisplayName("librarian adds book, updates it, appends inventory. User borrows book, returns it, same action do second user, but previously reserved it")
-//    void useCase() {
-//        final BoundedContext boundedContext = BoundedContexts.create();
-//        final CommandBus commandBus = boundedContext.getCommandBus();
-//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-//        boundedContext.getRejectionBus()
-//                      .register(bookRejectionsSubscriber);
-//        boundedContext.getRejectionBus()
-//                      .register(inventoryRejectionsSubscriber);
-//        commandBus.post(addBook, observer);
-//        commandBus.post(updateBook, observer);
-//        commandBus.post(appendInventory, observer);
-//        commandBus.post(borrowBook, observer);
-//        commandBus.post(reserveBook2, observer);
-//        commandBus.post(returnBook, observer);
-//        commandBus.post(borrowBook2, observer);
-//        commandBus.post(returnBook2, observer);
-//        assertFalse(bookRejectionsSubscriber.wasCalled());
-//        assertFalse(inventoryRejectionsSubscriber.wasCalled());
-//    }
-//
-//    @Test
-//    @DisplayName("librarian adds book, appends inventory. " +
-//            "Users borrow books, one user lost the book and the book is written off, another user returns the book.")
-//    void secondUseCase() {
-//        final BoundedContext boundedContext = BoundedContexts.create();
-//        final CommandBus commandBus = boundedContext.getCommandBus();
-//
-//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-//
-//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-//
-//        boundedContext.getRejectionBus()
-//                      .register(bookRejectionsSubscriber);
-//        boundedContext.getRejectionBus()
-//                      .register(inventoryRejectionsSubscriber);
-//
-//        commandBus.post(addBook, observer);
-//
-//        commandBus.post(appendInventory, observer);
-//        commandBus.post(appendInventory2, observer);
-//
-//        commandBus.post(borrowBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(borrowBook3, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(reserveBook, observer);
-//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-//        InventoryRejectionsSubscriber.clear();
-//
-//        commandBus.post(extendLoanPeriod, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(returnBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(borrowBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(writeBookOff, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(returnBook3, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(appendInventory, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(borrowBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(returnBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//    }
-//
-//    @Test
-//    @DisplayName("attempt to update, borrow, return missing book leads to rejection, same actions are allowed when book is added.")
-//    void rejectionsThrow() {
-//        final BoundedContext boundedContext = BoundedContexts.create();
-//        final CommandBus commandBus = boundedContext.getCommandBus();
-//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-//        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
-//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-//        boundedContext.getRejectionBus()
-//                      .register(bookRejectionsSubscriber);
-//        boundedContext.getRejectionBus()
-//                      .register(inventoryRejectionsSubscriber);
-//
-//        commandBus.post(borrowBook, observer);
-//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-//        InventoryRejectionsSubscriber.clear();
-//
-//        commandBus.post(updateBook, observer);
-//        assertTrue(BookRejectionsSubscriber.wasCalled());
-//        BookRejectionsSubscriber.clear();
-//
-//        commandBus.post(addBook, observer);
-//        assertFalse(BookRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(returnBook, observer);
-//        assertTrue(InventoryRejectionsSubscriber.wasCalled());
-//        InventoryRejectionsSubscriber.clear();
-//
-//        commandBus.post(appendInventory, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(updateBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//
-//        commandBus.post(borrowBook, observer);
-//        assertFalse(InventoryRejectionsSubscriber.wasCalled());
-//    }
-//
-//    @Test
-//    @DisplayName("two users by turns borrow book and few times extend their loan periods")
-//    void loanFlow() {
-//        final BoundedContext boundedContext = BoundedContexts.create();
-//        final CommandBus commandBus = boundedContext.getCommandBus();
-//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-//
-//        boundedContext.getRejectionBus()
-//                      .register(inventoryRejectionsSubscriber);
-//        commandBus.post(addBook, observer);
-//        commandBus.post(appendInventory, observer);
-//        commandBus.post(borrowBook, observer);
-//        commandBus.post(extendLoanPeriod, observer);
-//        commandBus.post(extendLoanPeriod, observer);
-//        commandBus.post(returnBook, observer);
-//        commandBus.post(borrowBook2, observer);
-//        commandBus.post(extendLoanPeriod2, observer);
-//        commandBus.post(extendLoanPeriod2, observer);
-//        commandBus.post(returnBook2, observer);
-//        assertFalse(inventoryRejectionsSubscriber.wasCalled());
-//    }
-//
-//    @Test
-//    @DisplayName("rejection when user to tries extend loan period without taking a book")
-//    void extendLoan() {
-//        final BoundedContext boundedContext = BoundedContexts.create();
-//        final CommandBus commandBus = boundedContext.getCommandBus();
-//        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
-//        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-//
-//        boundedContext.getRejectionBus()
-//                      .register(inventoryRejectionsSubscriber);
-//        commandBus.post(addBook, observer);
-//        commandBus.post(appendInventory, observer);
-//
-//        commandBus.post(borrowBook, observer);
-//        commandBus.post(extendLoanPeriod2, observer);
-//        assertTrue(inventoryRejectionsSubscriber.wasCalled());
-//        InventoryRejectionsSubscriber.clear();
-//    }
-//}
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.integrational;
+
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
+import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
+import io.spine.core.Command;
+import io.spine.grpc.StreamObservers;
+import io.spine.server.BoundedContext;
+import io.spine.server.commandbus.CommandBus;
+import javaclasses.exlibris.BookDetailsChange;
+import javaclasses.exlibris.BoundedContexts;
+import javaclasses.exlibris.c.RemoveBook;
+import javaclasses.exlibris.c.inventory.InventoryCommandTest;
+import javaclasses.exlibris.testdata.BookCommandFactory;
+import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
+import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.protobuf.TypeConverter.toMessage;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.removeBookInstance;
+import static javaclasses.exlibris.testdata.BookCommandFactory.updateBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.writeBookOffInstance;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Alexander Karpets
+ * @author Paul Ageyev
+ */
+public class FlowTest extends InventoryCommandTest<Message> {
+
+    private final TestActorRequestFactory requestFactory =
+            TestActorRequestFactory.newInstance(getClass());
+
+    private final BookDetailsChange newBookDetails = BookDetailsChange.newBuilder()
+                                                                      .setNewBookDetails(
+                                                                              BookCommandFactory.bookDetails2)
+                                                                      .build();
+
+    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
+
+    private final Command updateBook = requestFactory.createCommand(
+            toMessage(updateBookInstance(BookCommandFactory.bookId,
+                                         BookCommandFactory.userId2,
+                                         newBookDetails)));
+    private final Command appendInventory = requestFactory.createCommand(
+            toMessage(appendInventoryInstance()));
+
+    private final Command appendInventory2 = requestFactory.createCommand(
+            toMessage(appendInventoryInstance(InventoryCommandFactory.inventoryId,
+                                              InventoryCommandFactory.inventoryItemId2,
+                                              InventoryCommandFactory.userId)));
+
+    private final Command borrowBook = requestFactory.createCommand(
+            toMessage(borrowBookInstance()));
+
+    private final Command borrowBook2 = requestFactory.createCommand(
+            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
+                                         InventoryCommandFactory.inventoryItemId,
+                                         InventoryCommandFactory.userId2)));
+
+    private final Command borrowBook3 = requestFactory.createCommand(
+            toMessage(borrowBookInstance(InventoryCommandFactory.inventoryId,
+                                         InventoryCommandFactory.inventoryItemId2,
+                                         InventoryCommandFactory.userId2)));
+
+    private final Command reserveBook = requestFactory.createCommand(
+            toMessage(reserveBookInstance(InventoryCommandFactory.userId,
+                                          InventoryCommandFactory.inventoryId)));
+
+    private final Command reserveBook2 = requestFactory.createCommand(
+            toMessage(reserveBookInstance(InventoryCommandFactory.userId2,
+                                          InventoryCommandFactory.inventoryId)));
+
+    private final Command returnBook = requestFactory.createCommand(
+            toMessage(returnBookInstance()));
+
+    private final Command returnBook2 = requestFactory.createCommand(
+            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
+                                         InventoryCommandFactory.inventoryItemId,
+                                         InventoryCommandFactory.userId2)));
+
+    private final Command returnBook3 = requestFactory.createCommand(
+            toMessage(returnBookInstance(InventoryCommandFactory.inventoryId,
+                                         InventoryCommandFactory.inventoryItemId2,
+                                         InventoryCommandFactory.userId2)));
+
+    private final Command writeBookOff = requestFactory.createCommand(
+            toMessage(writeBookOffInstance()));
+
+    private final Command removeBook = requestFactory.createCommand(
+            toMessage(removeBookInstance(BookCommandFactory.bookId,
+                                         BookCommandFactory.librarianId,
+                                         RemoveBook.BookRemovalReasonCase.OUTDATED)));
+
+    private final Command extendLoanPeriod = requestFactory.createCommand(
+            toMessage(extendLoanPeriodInstance()));
+
+    private final Command extendLoanPeriod2 = requestFactory.createCommand(
+            toMessage(extendLoanPeriodInstance(InventoryCommandFactory.inventoryId,
+                                               InventoryCommandFactory.loan.getLoanId(),
+                                               InventoryCommandFactory.userId2)));
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    @DisplayName("librarian adds book, updates it, appends inventory. User borrows book, returns it, same action do second user, but previously reserved it")
+    void useCase() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+        commandBus.post(updateBook, observer);
+        commandBus.post(appendInventory, observer);
+        commandBus.post(borrowBook, observer);
+        commandBus.post(reserveBook2, observer);
+        commandBus.post(returnBook, observer);
+        commandBus.post(borrowBook2, observer);
+        commandBus.post(returnBook2, observer);
+        assertFalse(bookRejectionsSubscriber.wasCalled());
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("librarian adds book, appends inventory. " +
+            "Users borrow books, one user lost the book and the book is written off, another user returns the book.")
+    void secondUseCase() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+
+        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+
+        commandBus.post(addBook, observer);
+
+        commandBus.post(appendInventory, observer);
+        commandBus.post(appendInventory2, observer);
+
+        commandBus.post(borrowBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(borrowBook3, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(reserveBook, observer);
+        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+        InventoryRejectionsSubscriber.clear();
+
+        commandBus.post(extendLoanPeriod, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(returnBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(borrowBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(writeBookOff, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(returnBook3, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(appendInventory, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(borrowBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(returnBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("attempt to update, borrow, return missing book leads to rejection, same actions are allowed when book is added.")
+    void rejectionsThrow() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+
+        commandBus.post(borrowBook, observer);
+        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+        InventoryRejectionsSubscriber.clear();
+
+        commandBus.post(updateBook, observer);
+        assertTrue(BookRejectionsSubscriber.wasCalled());
+        BookRejectionsSubscriber.clear();
+
+        commandBus.post(addBook, observer);
+        assertFalse(BookRejectionsSubscriber.wasCalled());
+
+        commandBus.post(returnBook, observer);
+        assertTrue(InventoryRejectionsSubscriber.wasCalled());
+        InventoryRejectionsSubscriber.clear();
+
+        commandBus.post(appendInventory, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(updateBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(borrowBook, observer);
+        assertFalse(InventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("two users by turns borrow book and few times extend their loan periods")
+    void loanFlow() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+        commandBus.post(appendInventory, observer);
+        commandBus.post(borrowBook, observer);
+        commandBus.post(extendLoanPeriod, observer);
+        commandBus.post(extendLoanPeriod, observer);
+        commandBus.post(returnBook, observer);
+        commandBus.post(borrowBook2, observer);
+        commandBus.post(extendLoanPeriod2, observer);
+        commandBus.post(extendLoanPeriod2, observer);
+        commandBus.post(returnBook2, observer);
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("rejection when user to tries extend loan period without taking a book")
+    void extendLoan() {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        final CommandBus commandBus = boundedContext.getCommandBus();
+        final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+        final InventoryRejectionsSubscriber inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+        commandBus.post(appendInventory, observer);
+
+        commandBus.post(borrowBook, observer);
+        commandBus.post(extendLoanPeriod2, observer);
+        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+        InventoryRejectionsSubscriber.clear();
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/SubscribersTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/SubscribersTest.java
@@ -67,12 +67,12 @@ public class SubscribersTest extends BookCommandTest<AddBook> {
 
         rejectionBus.register(bookRejectionsSubscriber);
 
-        assertNull(BookRejectionsSubscriber.getRejection());
+        assertNull(bookRejectionsSubscriber.getRejection());
 
         commandBus.post(addBook, StreamObservers.noOpObserver());
         commandBus.post(addBook, StreamObservers.noOpObserver());
 
-        Rejections.BookAlreadyExists bookAlreadyExists = BookRejectionsSubscriber.getRejection();
+        Rejections.BookAlreadyExists bookAlreadyExists = bookRejectionsSubscriber.getRejection();
 
         assertEquals(userId, bookAlreadyExists.getLibrarianId());
         assertEquals(bookId, bookAlreadyExists.getBookId());
@@ -92,7 +92,7 @@ public class SubscribersTest extends BookCommandTest<AddBook> {
         eventBus.register(eventSubscriber);
 
         commandBus.post(addBook, StreamObservers.noOpObserver());
-        final BookAdded event = BookEventSubscriber.getEvent();
+        final BookAdded event = eventSubscriber.getEvent();
         assertEquals(bookId, event.getBookId());
         assertEquals(bookTitle, event.getDetails()
                                      .getTitle());

--- a/api-java/src/test/java/javaclasses/exlibris/c/integrational/SubscribersTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/integrational/SubscribersTest.java
@@ -39,9 +39,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.protobuf.TypeConverter.toMessage;
+import static javaclasses.exlibris.testdata.BookCommandFactory.bookId;
 import static javaclasses.exlibris.testdata.BookCommandFactory.bookTitle;
-import static javaclasses.exlibris.testdata.BookCommandFactory.isbn62Value;
-import static javaclasses.exlibris.testdata.BookCommandFactory.userEmailAddress1;
+import static javaclasses.exlibris.testdata.BookCommandFactory.userId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -61,12 +61,11 @@ public class SubscribersTest extends BookCommandTest<AddBook> {
         final RejectionBus rejectionBus = boundedContext.getRejectionBus();
 
         final Command addBook = requestFactory.createCommand(
-                toMessage(
-                        BookCommandFactory.createBookInstance()));
+                toMessage(BookCommandFactory.createBookInstance()));
 
-        final BookRejectionsSubscriber vendorRejectionsSubscriber = new BookRejectionsSubscriber();
+        final BookRejectionsSubscriber bookRejectionsSubscriber = new BookRejectionsSubscriber();
 
-        rejectionBus.register(vendorRejectionsSubscriber);
+        rejectionBus.register(bookRejectionsSubscriber);
 
         assertNull(BookRejectionsSubscriber.getRejection());
 
@@ -75,10 +74,8 @@ public class SubscribersTest extends BookCommandTest<AddBook> {
 
         Rejections.BookAlreadyExists bookAlreadyExists = BookRejectionsSubscriber.getRejection();
 
-        assertEquals(userEmailAddress1, bookAlreadyExists.getLibrarianId()
-                                                         .getEmail());
-        assertEquals(isbn62Value, bookAlreadyExists.getBookId()
-                                                   .getIsbn62());
+        assertEquals(userId, bookAlreadyExists.getLibrarianId());
+        assertEquals(bookId, bookAlreadyExists.getBookId());
         assertEquals(bookTitle, bookAlreadyExists.getBookTitle());
     }
 
@@ -88,19 +85,17 @@ public class SubscribersTest extends BookCommandTest<AddBook> {
         final BoundedContext boundedContext = BoundedContexts.create();
         final CommandBus commandBus = boundedContext.getCommandBus();
         final EventBus eventBus = boundedContext.getEventBus();
-        final Command addBook = requestFactory.command()
-                                              .create(toMessage(
-                                                      BookCommandFactory.createBookInstance()));
-
+        final Command addBook =
+                requestFactory.command()
+                              .create(toMessage(BookCommandFactory.createBookInstance()));
         final BookEventSubscriber eventSubscriber = new BookEventSubscriber();
         eventBus.register(eventSubscriber);
+
         commandBus.post(addBook, StreamObservers.noOpObserver());
         final BookAdded event = BookEventSubscriber.getEvent();
-        assertEquals(isbn62Value, event.getBookId()
-                                       .getIsbn62());
+        assertEquals(bookId, event.getBookId());
         assertEquals(bookTitle, event.getDetails()
                                      .getTitle());
-        assertEquals(userEmailAddress1, event.getLibrarianId()
-                                             .getEmail());
+        assertEquals(userId, event.getLibrarianId());
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/AllowLoansExtensionCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/AllowLoansExtensionCommandTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.inventory;
+
+import com.google.protobuf.Message;
+import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.Loan;
+import javaclasses.exlibris.UserId;
+import javaclasses.exlibris.c.AllowLoansExtension;
+import javaclasses.exlibris.c.AppendInventory;
+import javaclasses.exlibris.c.BorrowBook;
+import javaclasses.exlibris.c.ForbidLoansExtension;
+import javaclasses.exlibris.c.LoansExtensionAllowed;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.allowLoansExtensionInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.forbidLoansExtensionInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Yegor Udovchenko
+ */
+@DisplayName("AllowLoansExtension command should be interpreted by InventoryAggregate and")
+public class AllowLoansExtensionCommandTest extends InventoryCommandTest<AllowLoansExtension> {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        appendInventory();
+        borrowBook();
+        forbidLoansExtension();
+    }
+
+    @Test
+    @DisplayName("produce LoansExtensionAllowed event")
+    void produceEvent() {
+        final AllowLoansExtension allowLoansExtension =
+                allowLoansExtensionInstance(inventoryId, Collections.singletonList(userId));
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(allowLoansExtension));
+
+        assertEquals(1, messageList.size());
+        assertEquals(LoansExtensionAllowed.class, messageList.get(0)
+                                                             .getClass());
+        final LoansExtensionAllowed loansExtensionAllowed =
+                (LoansExtensionAllowed) messageList.get(0);
+        final UserId borrower = loansExtensionAllowed.getBorrowers(0);
+        assertEquals(userId, borrower);
+    }
+
+    @Test
+    @DisplayName("change loan status to allowed for extension")
+    void changeLoanStatus() {
+        final Inventory stateBefore = aggregate.getState();
+        final Loan loan = stateBefore.getLoans(0);
+        assertFalse(loan.getIsAllowedExtension());
+        final AllowLoansExtension allowLoansExtension =
+                allowLoansExtensionInstance(inventoryId, Collections.singletonList(userId));
+        dispatchCommand(aggregate, envelopeOf(allowLoansExtension));
+
+        final Inventory stateAfter = aggregate.getState();
+        final Loan updatedLoan = stateAfter.getLoans(0);
+        assertTrue(updatedLoan.getIsAllowedExtension());
+    }
+
+    private void appendInventory() {
+        final AppendInventory appendInventory = InventoryCommandFactory.appendInventoryInstance();
+        dispatchCommand(aggregate, envelopeOf(appendInventory));
+    }
+
+    private void borrowBook() {
+        final BorrowBook borrowBook = InventoryCommandFactory.borrowBookInstance();
+        dispatchCommand(aggregate, envelopeOf(borrowBook));
+    }
+
+    private void forbidLoansExtension() {
+        List<UserId> borrowers = Collections.singletonList(userId);
+        final ForbidLoansExtension forbidLoansExtension = forbidLoansExtensionInstance(inventoryId,
+                                                                                       borrowers);
+        dispatchCommand(aggregate, envelopeOf(forbidLoansExtension));
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/AppendInventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/AppendInventoryCommandTest.java
@@ -60,7 +60,7 @@ public class AppendInventoryCommandTest extends InventoryCommandTest<AppendInven
                                                                     envelopeOf(appendInventory));
 
         assertNotNull(aggregate.getId());
-        assertEquals(2, messageList.size());
+        assertEquals(1, messageList.size());
         assertEquals(InventoryAppended.class, messageList.get(0)
                                                          .getClass());
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/AppendInventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/AppendInventoryCommandTest.java
@@ -22,9 +22,10 @@ package javaclasses.exlibris.c.inventory;
 
 import com.google.protobuf.Message;
 import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.InventoryItem;
+import javaclasses.exlibris.InventoryItemId;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.InventoryAppended;
-import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,11 +69,12 @@ public class AppendInventoryCommandTest extends InventoryCommandTest<AppendInven
 
         assertEquals(InventoryCommandFactory.inventoryId, inventoryAppended.getInventoryId());
         assertEquals(InventoryCommandFactory.userId, inventoryAppended.getLibrarianId());
-
+        assertEquals(InventoryCommandFactory.inventoryItemId,
+                     inventoryAppended.getInventoryItemId());
     }
 
     @Test
-    @DisplayName("append inventory with no reservations")
+    @DisplayName("add inventory item to the state")
     void appendInventoryWithoutReservation() {
         final AppendInventory appendInventory = InventoryCommandFactory.appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
@@ -80,64 +82,20 @@ public class AppendInventoryCommandTest extends InventoryCommandTest<AppendInven
         final Inventory inventory = aggregate.getState();
         assertEquals(1, inventory.getInventoryItemsList()
                                  .size());
-        assertEquals(true, inventory.getInventoryItemsList()
-                                    .get(0)
-                                    .getInLibrary());
-        assertEquals(false, inventory.getInventoryItemsList()
-                                     .get(0)
-                                     .getLost());
-        assertEquals(false, inventory.getInventoryItemsList()
-                                     .get(0)
-                                     .getBorrowed());
-        assertEquals(1, inventory.getInventoryItemsList()
-                                 .get(0)
-                                 .getInventoryItemId()
-                                 .getItemNumber());
-        assertEquals(isbn62, inventory.getInventoryItemsList()
-                                      .get(0)
-                                      .getInventoryItemId()
-                                      .getBookId()
-                                      .getIsbn62());
-        assertEquals("", inventory.getInventoryItemsList()
-                                  .get(0)
-                                  .getUserId()
-                                  .getEmail()
-                                  .getValue());
-    }
 
-    @Test
-    @DisplayName("append inventory with reservation")
-    void appendInventoryWithReservation() {
-        final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance();
-        dispatchCommand(aggregate, envelopeOf(reserveBook));
+        final InventoryItem appendedItem = inventory.getInventoryItemsList()
+                                                    .get(0);
+        assertTrue(appendedItem.getInLibrary());
+        assertFalse(appendedItem.getLost());
+        assertFalse(appendedItem.getBorrowed());
+        final String userEmailValue = appendedItem.getUserId()
+                                                  .getEmail()
+                                                  .getValue();
+        assertEquals("", userEmailValue);
 
-        final AppendInventory appendInventory = InventoryCommandFactory.appendInventoryInstance();
-        dispatchCommand(aggregate, envelopeOf(appendInventory));
-        final Inventory inventory = aggregate.getState();
-        assertEquals(1, inventory.getInventoryItemsList()
-                                 .size());
-        assertTrue(inventory.getInventoryItemsList()
-                            .get(0)
-                            .getInLibrary());
-        assertFalse(inventory.getInventoryItemsList()
-                             .get(0)
-                             .getLost());
-        assertFalse(inventory.getInventoryItemsList()
-                             .get(0)
-                             .getBorrowed());
-        assertEquals(1, inventory.getInventoryItemsList()
-                                 .get(0)
-                                 .getInventoryItemId()
-                                 .getItemNumber());
-        assertEquals(isbn62, inventory.getInventoryItemsList()
-                                      .get(0)
-                                      .getInventoryItemId()
-                                      .getBookId()
-                                      .getIsbn62());
-        assertEquals("", inventory.getInventoryItemsList()
-                                  .get(0)
-                                  .getUserId()
-                                  .getEmail()
-                                  .getValue());
+        final InventoryItemId inventoryItemId = appendedItem.getInventoryItemId();
+        assertEquals(1, inventoryItemId.getItemNumber());
+        assertEquals(isbn62, inventoryItemId.getBookId()
+                                            .getIsbn62());
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
@@ -41,7 +41,6 @@ import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInvent
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId2;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.rfid;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId3;
@@ -174,8 +173,7 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
 
         final AppendInventory appendInventoryCommand = appendInventoryInstance(inventoryId,
                                                                                inventoryItemId2,
-                                                                               userId,
-                                                                               rfid);
+                                                                               userId);
         dispatchCommand(aggregate,
                         envelopeOf(appendInventoryCommand));
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
@@ -121,8 +121,8 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
     @Test
     @DisplayName("produce ReservationBecameLoan event when borrowing is a consequence of reservation.")
     void produceReservationBecameLoanEvent() {
-        dispatchAppendInventory();
         dispatchReserveBook();
+        dispatchAppendInventory();
         dispatchSatisfyReservation();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
@@ -139,8 +139,8 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
     @Test
     @DisplayName("remove reservation when borrowing is a consequence of reservation.")
     void removeReservationWhenBecameLoan() {
-        dispatchAppendInventory();
         dispatchReserveBook();
+        dispatchAppendInventory();
         dispatchSatisfyReservation();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
@@ -200,8 +200,8 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
     @DisplayName("throw NonAvailableBook rejection upon " +
             "an attempt to borrow a book with unsatisfied reservation")
     void borrowWithUnsatisfiedReservation() {
-        dispatchAppendInventory();
         dispatchReserveBook();
+        dispatchAppendInventory();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId,
                                                          inventoryItemId,
@@ -218,8 +218,8 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
     @DisplayName("throw NonAvailableBook rejection upon " +
             "an attempt to borrow a book that satisfies someone's reservation")
     void borrowNotPublicAvailableBookReservation() {
-        dispatchAppendInventory();
         dispatchReserveBook();
+        dispatchAppendInventory();
         dispatchSatisfyReservation();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId,

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/BorrowBookCommandTest.java
@@ -23,10 +23,16 @@ package javaclasses.exlibris.c.inventory;
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
 import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.InventoryItem;
+import javaclasses.exlibris.InventoryItemId;
+import javaclasses.exlibris.Loan;
+import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BookBorrowed;
 import javaclasses.exlibris.c.BorrowBook;
+import javaclasses.exlibris.c.ReservationBecameLoan;
 import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.c.SatisfyReservation;
 import javaclasses.exlibris.c.rejection.BookAlreadyBorrowed;
 import javaclasses.exlibris.c.rejection.NonAvailableBook;
 import javaclasses.exlibris.testdata.InventoryCommandFactory;
@@ -39,11 +45,11 @@ import java.util.List;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId2;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId3;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Dmytry Dyachenko
  * @author Alexander Karpets
  * @author Paul Ageyev
+ * @author Yegor Udovchenko
  */
 @DisplayName("BorrowBook command should be interpreted by InventoryAggregate and")
 public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
@@ -66,34 +73,34 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
 
     @Test
     @DisplayName("produce BookBorrowed event")
-    void produceEvent() {
+    void produceBookBorrowedEvent() {
         dispatchAppendInventory();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
-
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(borrowBook));
         assertEquals(2, messageList.size());
         assertEquals(BookBorrowed.class, messageList.get(0)
                                                     .getClass());
         final BookBorrowed bookBorrowed = (BookBorrowed) messageList.get(0);
-
+        final InventoryItemId borrowedItemId = bookBorrowed.getInventoryItemId();
+        final UserId whoBorrowed = bookBorrowed.getWhoBorrowed();
         assertEquals(inventoryId, bookBorrowed.getInventoryId());
+        assertEquals(inventoryItemId, borrowedItemId);
+        assertEquals(userId, whoBorrowed);
     }
 
     @Test
-    @DisplayName("borrow the book")
+    @DisplayName("change the inventory item state to borrowed.")
     void borrowBook() {
         dispatchAppendInventory();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
-
         dispatchCommand(aggregate, envelopeOf(borrowBook));
         final Inventory state = aggregate.getState();
-
-        assertTrue(state.getInventoryItems(0)
-                        .getBorrowed());
-
+        final InventoryItem borrowedItem = state.getInventoryItems(0);
+        assertTrue(borrowedItem.getBorrowed());
+        assertEquals(userId, borrowedItem.getUserId());
     }
 
     @Test
@@ -102,96 +109,128 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
         dispatchAppendInventory();
 
         final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
-
         dispatchCommand(aggregate, envelopeOf(borrowBook));
+
         final Inventory state = aggregate.getState();
-
         assertEquals(1, state.getLoansCount());
-
-        assertEquals(state.getLoans(state.getLoansCount() - 1)
-                          .getInventoryItemId(), inventoryItemId);
-
-        assertEquals(state.getLoans(state.getLoansCount() - 1)
-                          .getWhoBorrowed(), userId);
-
+        final Loan loan = state.getLoans(0);
+        assertEquals(loan.getInventoryItemId(), inventoryItemId);
+        assertEquals(loan.getWhoBorrowed(), userId);
     }
 
     @Test
-    @DisplayName("reservation became loan")
-    void reservationBecameLoan() {
+    @DisplayName("produce ReservationBecameLoan event when borrowing is a consequence of reservation.")
+    void produceReservationBecameLoanEvent() {
         dispatchAppendInventory();
         dispatchReserveBook();
+        dispatchSatisfyReservation();
 
-        final BorrowBook borrowBook = borrowBookInstance(InventoryCommandFactory.inventoryId,
-                                                         InventoryCommandFactory.inventoryItemId,
-                                                         InventoryCommandFactory.userId);
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
+        final List<? extends Message> messageList = dispatchCommand(aggregate,
+                                                                    envelopeOf(borrowBook));
+        assertEquals(2, messageList.size());
+        assertEquals(ReservationBecameLoan.class, messageList.get(1)
+                                                             .getClass());
 
-        dispatchCommand(aggregate, envelopeOf(borrowBook));
-        final Inventory state = aggregate.getState();
-
-        assertEquals(1, state.getLoansCount());
-
-        assertEquals(state.getLoans(state.getLoansCount() - 1)
-                          .getInventoryItemId(), inventoryItemId);
-
-        assertEquals(state.getLoans(state.getLoansCount() - 1)
-                          .getWhoBorrowed(), userId);
-        assertEquals(0, state.getReservationsList()
-                             .size());
-
+        final ReservationBecameLoan becameLoan = (ReservationBecameLoan) messageList.get(1);
+        assertEquals(userId, becameLoan.getUserId());
     }
 
     @Test
-    @DisplayName("throw CannotBorrowBook rejection upon " +
-            "an attempt to borrow a book that has already borrowed")
-    void bookAlreadyBorrowed() {
+    @DisplayName("remove reservation when borrowing is a consequence of reservation.")
+    void removeReservationWhenBecameLoan() {
         dispatchAppendInventory();
+        dispatchReserveBook();
+        dispatchSatisfyReservation();
 
-        final BorrowBook borrowBook = borrowBookInstance(InventoryCommandFactory.inventoryId,
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
+        dispatchCommand(aggregate, envelopeOf(borrowBook));
+
+        final Inventory state = aggregate.getState();
+
+        assertEquals(1, state.getLoansCount());
+        assertEquals(0, state.getReservationsCount());
+    }
+
+    @Test
+    @DisplayName("throw BookAlreadyBorrowed rejection upon " +
+            "an attempt to borrow a book more than 1 book")
+    void throwBookAlreadyBorrowed() {
+        dispatchAppendInventoryTwice();
+
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId,
                                                          inventoryItemId, userId);
 
         dispatchCommand(aggregate, envelopeOf(borrowBook));
 
+        final BorrowBook borrowOneMoreBook = borrowBookInstance(inventoryId,
+                                                                inventoryItemId2, userId);
+
         final Throwable t = assertThrows(Throwable.class,
                                          () -> dispatchCommand(aggregate,
-                                                               envelopeOf(borrowBook)));
+                                                               envelopeOf(borrowOneMoreBook)));
         final Throwable cause = Throwables.getRootCause(t);
-
         assertThat(cause, instanceOf(BookAlreadyBorrowed.class));
     }
 
     @Test
-    @DisplayName("throw CannotBorrowBook rejection upon " +
-            "an attempt to borrow a book that isn't available")
-    void notAvailableBook() {
+    @DisplayName("throw NonAvailableBook rejection upon " +
+            "an attempt to borrow a book item that is already borrowed")
+    void borrowingSomeonesBook() {
         dispatchAppendInventory();
 
-        final BorrowBook borrowBook = borrowBookInstance(InventoryCommandFactory.inventoryId,
-                                                         inventoryItemId, userId);
+        final BorrowBook borrowBookForSomeone = borrowBookInstance(inventoryId,
+                                                                   inventoryItemId,
+                                                                   userId);
+        dispatchCommand(aggregate, envelopeOf(borrowBookForSomeone));
 
-        dispatchCommand(aggregate, envelopeOf(borrowBook));
-
-        final AppendInventory appendInventoryCommand = appendInventoryInstance(inventoryId,
-                                                                               inventoryItemId2,
-                                                                               userId);
-        dispatchCommand(aggregate,
-                        envelopeOf(appendInventoryCommand));
-
-        final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance(userId2,
-                                                                                    InventoryCommandFactory.inventoryId);
-
-        dispatchCommand(aggregate, envelopeOf(reserveBook));
-
-        final BorrowBook borrowBook2 = borrowBookInstance(InventoryCommandFactory.inventoryId,
-                                                          inventoryItemId, userId3);
+        final BorrowBook borrowSomeOnesBook = borrowBookInstance(inventoryId,
+                                                                 inventoryItemId,
+                                                                 userId2);
 
         final Throwable t = assertThrows(Throwable.class,
                                          () -> dispatchCommand(aggregate,
-                                                               envelopeOf(borrowBook2)));
+                                                               envelopeOf(borrowSomeOnesBook)));
+
         final Throwable cause = Throwables.getRootCause(t);
-
         assertThat(cause, instanceOf(NonAvailableBook.class));
+    }
 
+    @Test
+    @DisplayName("throw NonAvailableBook rejection upon " +
+            "an attempt to borrow a book with unsatisfied reservation")
+    void borrowWithUnsatisfiedReservation() {
+        dispatchAppendInventory();
+        dispatchReserveBook();
+
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId,
+                                                         inventoryItemId,
+                                                         userId);
+        final Throwable t = assertThrows(Throwable.class,
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(borrowBook)));
+
+        final Throwable cause = Throwables.getRootCause(t);
+        assertThat(cause, instanceOf(NonAvailableBook.class));
+    }
+
+    @Test
+    @DisplayName("throw NonAvailableBook rejection upon " +
+            "an attempt to borrow a book that satisfies someone's reservation")
+    void borrowNotPublicAvailableBookReservation() {
+        dispatchAppendInventory();
+        dispatchReserveBook();
+        dispatchSatisfyReservation();
+
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId,
+                                                         inventoryItemId,
+                                                         userId2);
+        final Throwable t = assertThrows(Throwable.class,
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(borrowBook)));
+
+        final Throwable cause = Throwables.getRootCause(t);
+        assertThat(cause, instanceOf(NonAvailableBook.class));
     }
 
     private void dispatchReserveBook() {
@@ -199,9 +238,22 @@ public class BorrowBookCommandTest extends InventoryCommandTest<BorrowBook> {
         dispatchCommand(aggregate, envelopeOf(reserveBook));
     }
 
+    private void dispatchSatisfyReservation() {
+        final SatisfyReservation satisfyReservation = InventoryCommandFactory.satisfyReservationInstance();
+        dispatchCommand(aggregate, envelopeOf(satisfyReservation));
+    }
+
     private void dispatchAppendInventory() {
         final AppendInventory appendInventory = appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
     }
 
+    private void dispatchAppendInventoryTwice() {
+        final AppendInventory appendInventory = appendInventoryInstance();
+        dispatchCommand(aggregate, envelopeOf(appendInventory));
+        final AppendInventory appendAnotherInventory = appendInventoryInstance(inventoryId,
+                                                                               inventoryItemId2,
+                                                                               userId);
+        dispatchCommand(aggregate, envelopeOf(appendAnotherInventory));
+    }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
@@ -195,6 +195,10 @@ public class ExtendLoanPeriodCommandTest extends InventoryCommandTest<ExtendLoan
         final LoanId loanId = state.getLoans(0)
                                    .getLoanId();
         List<UserId> borrowers = Collections.singletonList(whoBorrowed);
+        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(loanId, inventoryId);
+
+        dispatchCommand(aggregate, envelopeOf(markLoanOverdue));
+
         final ForbidLoansExtension forbidLoansExtension = forbidLoansExtensionInstance(inventoryId,
                                                                                        borrowers);
         dispatchCommand(aggregate, envelopeOf(forbidLoansExtension));

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
@@ -21,25 +21,34 @@
 package javaclasses.exlibris.c.inventory;
 
 import com.google.common.base.Throwables;
+import com.google.protobuf.Message;
 import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.LoanId;
+import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ExtendLoanPeriod;
-import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.c.ForbidLoansExtension;
+import javaclasses.exlibris.c.LoanPeriodExtended;
+import javaclasses.exlibris.c.MarkLoanOverdue;
+import javaclasses.exlibris.c.MarkLoanShouldReturnSoon;
 import javaclasses.exlibris.c.rejection.CannotExtendLoanPeriod;
-import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.forbidLoansExtensionInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanShouldReturnSoon;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Paul Ageyev
+ * @author Yegor Udovchenko
  */
 @DisplayName("ExtendLoanPeriod command should be interpreted by InventoryAggregate and")
 public class ExtendLoanPeriodCommandTest extends InventoryCommandTest<ExtendLoanPeriod> {
@@ -58,17 +68,38 @@ public class ExtendLoanPeriodCommandTest extends InventoryCommandTest<ExtendLoan
     }
 
     @Test
-    @DisplayName("extend a loan period")
-    void extendLoanPeriod() {
-        dispatchAppendInventory();
-
-        final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
-
-        dispatchCommand(aggregate, envelopeOf(borrowBook));
+    @DisplayName("produce LoanPeriodExtended event")
+    void produceEvent() {
+        borrowBook();
         final Inventory state = aggregate.getState();
+        final LoanId loanId = state.getLoans(0)
+                                   .getLoanId();
+        makeLoanOverdue(loanId);
 
+        final ExtendLoanPeriod extendLoanPeriod = extendLoanPeriodInstance(inventoryId,
+                                                                           loanId,
+                                                                           userId);
+        final List<? extends Message> messageList = dispatchCommand(aggregate,
+                                                                    envelopeOf(extendLoanPeriod));
+        assertEquals(1, messageList.size());
+        assertEquals(LoanPeriodExtended.class, messageList.get(0)
+                                                          .getClass());
+
+        final LoanPeriodExtended loanExtended = (LoanPeriodExtended) messageList.get(0);
+
+        assertEquals(inventoryId, loanExtended.getInventoryId());
+        assertEquals(userId, loanExtended.getUserId());
+    }
+
+    @Test
+    @DisplayName("extend a loan period of overdue loan")
+    void extendLoanPeriodOfOverdueLoan() {
+        borrowBook();
+        final Inventory state = aggregate.getState();
+        final LoanId loanId = state.getLoans(0)
+                                   .getLoanId();
+        makeLoanOverdue(loanId);
         long secondsInTwoWeeks = 60 * 60 * 24 * 14;
-
         assertEquals(state.getLoans(0)
                           .getWhenDue()
                           .getSeconds(), state.getLoans(0)
@@ -83,52 +114,116 @@ public class ExtendLoanPeriodCommandTest extends InventoryCommandTest<ExtendLoan
                                                                            userId);
 
         dispatchCommand(aggregate, envelopeOf(extendLoanPeriod));
-
-        final Inventory state2 = aggregate.getState();
-
-        assertEquals(oldDueDate + secondsInTwoWeeks, state2.getLoans(0)
-                                                           .getWhenDue()
-                                                           .getSeconds());
+        final Inventory stateAfterExtension = aggregate.getState();
+        assertEquals(oldDueDate + secondsInTwoWeeks, stateAfterExtension.getLoans(0)
+                                                                        .getWhenDue()
+                                                                        .getSeconds());
     }
 
     @Test
-    @DisplayName("throw CannotExtendLoanPeriod rejection upon " +
-            "an attempt to extend loan period if the book has already been reserved or borrowed")
-    void notExtendLoanPeriod() {
-        dispatchAppendInventory();
-
-        final BorrowBook borrowBook = borrowBookInstance(inventoryId, inventoryItemId, userId);
-
-        dispatchCommand(aggregate, envelopeOf(borrowBook));
+    @DisplayName("extend a loan period of should return soon loan")
+    void extendLoanPeriodOfShouldReturnSoonLoan() {
+        borrowBook();
         final Inventory state = aggregate.getState();
-
+        final LoanId loanId = state.getLoans(0)
+                                   .getLoanId();
+        makeLoanShouldReturnSoon(loanId);
         long secondsInTwoWeeks = 60 * 60 * 24 * 14;
-
         assertEquals(state.getLoans(0)
                           .getWhenDue()
                           .getSeconds(), state.getLoans(0)
                                               .getWhenTaken()
                                               .getSeconds() + secondsInTwoWeeks);
-
-        final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance(userId2, inventoryId);
-        dispatchCommand(aggregate, envelopeOf(reserveBook));
-
+        long oldDueDate = state.getLoans(0)
+                               .getWhenDue()
+                               .getSeconds();
         final ExtendLoanPeriod extendLoanPeriod = extendLoanPeriodInstance(inventoryId,
                                                                            state.getLoans(0)
                                                                                 .getLoanId(),
                                                                            userId);
 
+        dispatchCommand(aggregate, envelopeOf(extendLoanPeriod));
+        final Inventory stateAfterExtension = aggregate.getState();
+        assertEquals(oldDueDate + secondsInTwoWeeks, stateAfterExtension.getLoans(0)
+                                                                        .getWhenDue()
+                                                                        .getSeconds());
+    }
+
+    @Test
+    @DisplayName("throw CannotExtendLoanPeriod rejection upon " +
+            "an attempt to extend loan period of non existing loan")
+    void extendMissingLoan() {
+        final LoanId fakeLoanId = LoanId.newBuilder()
+                                        .setValue(0)
+                                        .build();
+        final ExtendLoanPeriod extendLoanPeriod = extendLoanPeriodInstance(inventoryId,
+                                                                           fakeLoanId,
+                                                                           userId);
         final Throwable t = assertThrows(Throwable.class,
                                          () -> dispatchCommand(aggregate,
                                                                envelopeOf(extendLoanPeriod)));
-
         final Throwable cause = Throwables.getRootCause(t);
-
         assertThat(cause, instanceOf(CannotExtendLoanPeriod.class));
     }
 
-    private void dispatchAppendInventory() {
+    @Test
+    @DisplayName("throw CannotExtendLoanPeriod rejection upon " +
+            "an attempt to extend loan period of a recent loan")
+    void extendRecentLoan() {
+        borrowBook();
+        final Inventory state = aggregate.getState();
+        final LoanId loanId = state.getLoans(0)
+                                   .getLoanId();
+        final ExtendLoanPeriod extendLoanPeriod = extendLoanPeriodInstance(inventoryId,
+                                                                           loanId,
+                                                                           userId);
+        final Throwable t = assertThrows(Throwable.class,
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(extendLoanPeriod)));
+        final Throwable cause = Throwables.getRootCause(t);
+        assertThat(cause, instanceOf(CannotExtendLoanPeriod.class));
+    }
+
+    @Test
+    @DisplayName("throw CannotExtendLoanPeriod rejection upon " +
+            "an attempt to extend loan which is forbidden for extension")
+    void extendLoanNotAllowedForExtension() {
+        borrowBook();
+        final Inventory state = aggregate.getState();
+        final UserId whoBorrowed = state.getLoans(0)
+                                        .getWhoBorrowed();
+        final LoanId loanId = state.getLoans(0)
+                                   .getLoanId();
+        List<UserId> borrowers = Collections.singletonList(whoBorrowed);
+        final ForbidLoansExtension forbidLoansExtension = forbidLoansExtensionInstance(inventoryId,
+                                                                                       borrowers);
+        dispatchCommand(aggregate, envelopeOf(forbidLoansExtension));
+
+        final ExtendLoanPeriod extendLoanPeriod = extendLoanPeriodInstance(inventoryId,
+                                                                           loanId,
+                                                                           userId);
+        final Throwable t = assertThrows(Throwable.class,
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(extendLoanPeriod)));
+        final Throwable cause = Throwables.getRootCause(t);
+        assertThat(cause, instanceOf(CannotExtendLoanPeriod.class));
+    }
+
+    private void borrowBook() {
         final AppendInventory appendInventory = appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
+        final BorrowBook borrowBook = borrowBookInstance();
+        dispatchCommand(aggregate, envelopeOf(borrowBook));
+    }
+
+    private void makeLoanOverdue(LoanId loanId) {
+        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(loanId, inventoryId);
+        dispatchCommand(aggregate, envelopeOf(markLoanOverdue));
+    }
+
+    private void makeLoanShouldReturnSoon(LoanId loanId) {
+        final MarkLoanShouldReturnSoon markLoanOverdue = markLoanShouldReturnSoon(loanId,
+                                                                                  inventoryId);
+        dispatchCommand(aggregate, envelopeOf(markLoanOverdue));
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ExtendLoanPeriodCommandTest.java
@@ -36,6 +36,7 @@ import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchComma
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ForbidLoansExtensionCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ForbidLoansExtensionCommandTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.inventory;
+
+import com.google.protobuf.Message;
+import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.Loan;
+import javaclasses.exlibris.UserId;
+import javaclasses.exlibris.c.AppendInventory;
+import javaclasses.exlibris.c.BorrowBook;
+import javaclasses.exlibris.c.ForbidLoansExtension;
+import javaclasses.exlibris.c.LoansExtensionForbidden;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.forbidLoansExtensionInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Yegor Udovchenko
+ */
+@DisplayName("ForbidLoansExtension command should be interpreted by InventoryAggregate and")
+public class ForbidLoansExtensionCommandTest extends InventoryCommandTest<ForbidLoansExtension> {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        appendInventory();
+        borrowBook();
+    }
+
+    @Test
+    @DisplayName("produce LoansExtensionForbidden event")
+    void produceEvent() {
+        List<UserId> borrowers = Collections.singletonList(userId);
+        final ForbidLoansExtension forbidLoansExtension = forbidLoansExtensionInstance(inventoryId,
+                                                                                       borrowers);
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(forbidLoansExtension));
+
+        assertEquals(1, messageList.size());
+        assertEquals(LoansExtensionForbidden.class, messageList.get(0)
+                                                               .getClass());
+        final LoansExtensionForbidden loansExtensionForbidden =
+                (LoansExtensionForbidden) messageList.get(0);
+        final UserId borrower = loansExtensionForbidden.getBorrowers(0);
+        assertEquals(userId, borrower);
+    }
+
+    @Test
+    @DisplayName("change loan status to forbidden for extension")
+    void changeLoanStatus() {
+        final Inventory stateBefore = aggregate.getState();
+        final Loan loan = stateBefore.getLoans(0);
+        assertTrue(loan.getIsAllowedExtension());
+        List<UserId> borrowers = Collections.singletonList(userId);
+        final ForbidLoansExtension forbidLoansExtension = forbidLoansExtensionInstance(inventoryId,
+                                                                                       borrowers);
+        dispatchCommand(aggregate, envelopeOf(forbidLoansExtension));
+
+        final Inventory stateAfter = aggregate.getState();
+        final Loan updatedLoan = stateAfter.getLoans(0);
+        assertFalse(updatedLoan.getIsAllowedExtension());
+    }
+
+    private void appendInventory() {
+        final AppendInventory appendInventory = InventoryCommandFactory.appendInventoryInstance();
+        dispatchCommand(aggregate, envelopeOf(appendInventory));
+    }
+
+    private void borrowBook() {
+        final BorrowBook borrowBook = InventoryCommandFactory.borrowBookInstance();
+        dispatchCommand(aggregate, envelopeOf(borrowBook));
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCommandTest.java
@@ -24,10 +24,8 @@ import com.google.protobuf.Message;
 import io.spine.client.TestActorRequestFactory;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.AggregateCommandTest;
-import javaclasses.exlibris.BookId;
-import javaclasses.exlibris.InventoryId;
 
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.isbn62;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 
 /**
  * @author Alexander Karpets
@@ -38,18 +36,9 @@ public class InventoryCommandTest<C extends Message> extends AggregateCommandTes
             TestActorRequestFactory.newInstance(getClass());
 
     InventoryAggregate aggregate;
-    InventoryId inventoryId;
-
-    private static InventoryId createBookId() {
-        return InventoryId.newBuilder()
-                          .setBookId(BookId.newBuilder()
-                                           .setIsbn62(isbn62))
-                          .build();
-    }
 
     @Override
     protected InventoryAggregate createAggregate() {
-        inventoryId = createBookId();
         return new InventoryAggregate(inventoryId);
     }
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCommandTest.java
@@ -35,7 +35,7 @@ public class InventoryCommandTest<C extends Message> extends AggregateCommandTes
     private final TestActorRequestFactory requestFactory =
             TestActorRequestFactory.newInstance(getClass());
 
-    InventoryAggregate aggregate;
+    public InventoryAggregate aggregate;
 
     @Override
     protected InventoryAggregate createAggregate() {

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCreatedTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryCreatedTest.java
@@ -70,11 +70,11 @@ public class InventoryCreatedTest {
 
         final Optional<Repository> repository = sourceContext.findRepository(Inventory.class);
 
+        final InventoryId inventoryId = InventoryId.newBuilder()
+                                                   .setBookId(bookAdded.getBookId())
+                                                   .build();
         final Optional<InventoryAggregate> optional = repository.get()
-                                                                .find(InventoryId.newBuilder()
-                                                                                 .setBookId(
-                                                                                         bookAdded.getBookId())
-                                                                                 .build());
+                                                                .find(inventoryId);
         assertNotNull(optional);
 
         assertEquals(optional.get()

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryRemovedTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/InventoryRemovedTest.java
@@ -67,11 +67,11 @@ public class InventoryRemovedTest extends InventoryCommandTest<AddBook> {
 
         final Optional<Repository> repository = sourceContext.findRepository(Inventory.class);
 
+        final InventoryId inventoryId = InventoryId.newBuilder()
+                                                   .setBookId(bookRemoved.getBookId())
+                                                   .build();
         final Optional<InventoryAggregate> optional = repository.get()
-                                                                .find(InventoryId.newBuilder()
-                                                                                 .setBookId(
-                                                                                         bookRemoved.getBookId())
-                                                                                 .build());
+                                                                .find(inventoryId);
 
         assertNotNull(optional);
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkBookAsAvailableCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkBookAsAvailableCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.inventory;
+
+import com.google.protobuf.Message;
+import javaclasses.exlibris.c.BookBecameAvailable;
+import javaclasses.exlibris.c.MarkBookAsAvailable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markBookAsAvailableInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Yegor Udovchenko
+ */
+@DisplayName("MarkBookAsAvailable command should be interpreted by InventoryAggregate and")
+public class MarkBookAsAvailableCommandTest extends InventoryCommandTest<MarkBookAsAvailable> {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    @DisplayName("produce BookBecameAvailable event")
+    void produceEvent() {
+        final MarkBookAsAvailable markBookAsAvailable = markBookAsAvailableInstance();
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(markBookAsAvailable));
+        final BookBecameAvailable bookBecameAvailable = (BookBecameAvailable) messageList.get(0);
+        final int availableBooksCount = bookBecameAvailable.getAvailableBooksCount();
+
+        assertEquals(1, availableBooksCount);
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkBookAsAvailableCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkBookAsAvailableCommandTest.java
@@ -53,6 +53,6 @@ public class MarkBookAsAvailableCommandTest extends InventoryCommandTest<MarkBoo
         final BookBecameAvailable bookBecameAvailable = (BookBecameAvailable) messageList.get(0);
         final int availableBooksCount = bookBecameAvailable.getAvailableBooksCount();
 
-        assertEquals(1, availableBooksCount);
+        assertEquals(0, availableBooksCount);
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
@@ -58,11 +58,9 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
     @Test
     @DisplayName("produce LoanBecameOverdue event")
     void produceEvent() {
-        dispatchAppendInventory();
+        final LoanId loanId = prepareLoan();
 
-        final LoanId eventLoanId = dispatchBorrowBookAndReturnLoanId();
-
-        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(eventLoanId, inventoryId);
+        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(loanId, inventoryId);
 
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(markLoanOverdue));
@@ -71,16 +69,13 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
                                                          .getClass());
         final LoanBecameOverdue loanBecameOverdue = (LoanBecameOverdue) messageList.get(0);
 
-        assertEquals(eventLoanId, loanBecameOverdue.getLoanId());
-
+        assertEquals(loanId, loanBecameOverdue.getLoanId());
     }
 
     @Test
     @DisplayName("marks loan as overdue")
     void markLoanPeriodAsOverdue() {
-        dispatchAppendInventory();
-
-        final LoanId eventLoanId = dispatchBorrowBookAndReturnLoanId();
+        final LoanId eventLoanId = prepareLoan();
 
         final MarkLoanOverdue markLoanOverdue = markLoanOverdue(eventLoanId, inventoryId);
 
@@ -89,7 +84,6 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
 
         assertTrue(state.getInventoryItems(0)
                         .getBorrowed());
-
         assertEquals(state.getLoans(0)
                           .getStatus(), LOAN_OVERDUE);
     }
@@ -99,9 +93,9 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
         dispatchCommand(aggregate, envelopeOf(appendInventory));
     }
 
-    private LoanId dispatchBorrowBookAndReturnLoanId() {
+    private LoanId prepareLoan() {
+        dispatchAppendInventory();
         final BorrowBook borrowBook = borrowBookInstance();
-
         final List<? extends Message> messages = dispatchCommand(aggregate, envelopeOf(borrowBook));
         final BookBorrowed bookBorrowed = (BookBorrowed) messages.get(0);
         return bookBorrowed.getLoanId();

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.LoanStatus.LOAN_OVERDUE;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
@@ -88,8 +89,8 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
         assertTrue(state.getInventoryItems(0)
                         .getBorrowed());
 
-        assertTrue(state.getLoans(0)
-                        .getOverdue());
+        assertEquals(state.getLoans(0)
+                          .getStatus(), LOAN_OVERDUE);
     }
 
     private void dispatchAppendInventory() {

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanOverdueCommandTest.java
@@ -38,6 +38,7 @@ import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchComma
 import static javaclasses.exlibris.LoanStatus.LOAN_OVERDUE;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanShouldReturnSoonCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkLoanShouldReturnSoonCommandTest.java
@@ -26,8 +26,8 @@ import javaclasses.exlibris.LoanId;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BookBorrowed;
 import javaclasses.exlibris.c.BorrowBook;
-import javaclasses.exlibris.c.LoanBecameOverdue;
-import javaclasses.exlibris.c.MarkLoanOverdue;
+import javaclasses.exlibris.c.LoanBecameShouldReturnSoon;
+import javaclasses.exlibris.c.MarkLoanShouldReturnSoon;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,19 +35,19 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
-import static javaclasses.exlibris.LoanStatus.LOAN_OVERDUE;
+import static javaclasses.exlibris.LoanStatus.LOAN_SOULD_RETURN_SOON;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanShouldReturnSoon;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Dmytry Dyachenko
+ * @author Yegor Udovchenko
  */
-@DisplayName("MarkLoanOverdue command should be interpreted by InventoryAggregate and")
-public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOverdue> {
+@DisplayName("MarkLoanShouldReturnSoon command should be interpreted by InventoryAggregate and")
+public class MarkLoanShouldReturnSoonCommandTest extends InventoryCommandTest<MarkLoanShouldReturnSoon> {
 
     @Override
     @BeforeEach
@@ -56,36 +56,37 @@ public class MarkLoanOverdueCommandTest extends InventoryCommandTest<MarkLoanOve
     }
 
     @Test
-    @DisplayName("produce LoanBecameOverdue event")
+    @DisplayName("produce LoanBecameShouldReturnSoon event")
     void produceEvent() {
         final LoanId loanId = prepareLoan();
 
-        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(loanId, inventoryId);
+        final MarkLoanShouldReturnSoon markLoanShouldReturnSoon = markLoanShouldReturnSoon(loanId,
+                                                                                           inventoryId);
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(markLoanShouldReturnSoon));
 
-        final List<? extends Message> messageList = dispatchCommand(aggregate,
-                                                                    envelopeOf(markLoanOverdue));
         assertEquals(1, messageList.size());
-        assertEquals(LoanBecameOverdue.class, messageList.get(0)
-                                                         .getClass());
-        final LoanBecameOverdue loanBecameOverdue = (LoanBecameOverdue) messageList.get(0);
-
-        assertEquals(loanId, loanBecameOverdue.getLoanId());
+        assertEquals(LoanBecameShouldReturnSoon.class, messageList.get(0)
+                                                                  .getClass());
+        final LoanBecameShouldReturnSoon becameShouldReturnSoon =
+                (LoanBecameShouldReturnSoon) messageList.get(0);
+        assertEquals(loanId, becameShouldReturnSoon.getLoanId());
     }
 
     @Test
-    @DisplayName("marks loan as overdue")
+    @DisplayName("marks loan as should return soon")
     void markLoanPeriodAsOverdue() {
         final LoanId loanId = prepareLoan();
 
-        final MarkLoanOverdue markLoanOverdue = markLoanOverdue(loanId, inventoryId);
-
-        dispatchCommand(aggregate, envelopeOf(markLoanOverdue));
+        final MarkLoanShouldReturnSoon markLoanShouldReturnSoon = markLoanShouldReturnSoon(loanId,
+                                                                                           inventoryId);
+        dispatchCommand(aggregate, envelopeOf(markLoanShouldReturnSoon));
         final Inventory state = aggregate.getState();
 
         assertTrue(state.getInventoryItems(0)
                         .getBorrowed());
         assertEquals(state.getLoans(0)
-                          .getStatus(), LOAN_OVERDUE);
+                          .getStatus(), LOAN_SOULD_RETURN_SOON);
     }
 
     @SuppressWarnings("Duplicates")

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkReservationExpiredCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/MarkReservationExpiredCommandTest.java
@@ -21,6 +21,7 @@
 package javaclasses.exlibris.c.inventory;
 
 import com.google.protobuf.Message;
+import javaclasses.exlibris.Inventory;
 import javaclasses.exlibris.c.MarkReservationExpired;
 import javaclasses.exlibris.c.ReservationPickUpPeriodExpired;
 import javaclasses.exlibris.c.ReserveBook;
@@ -33,13 +34,12 @@ import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Paul Ageyev
  */
-@DisplayName("ReservationPickUpPeriodExpiredCommandTest command should be interpreted by InventoryAggregate and")
-public class ReservationPickUpPeriodExpiredCommandTest extends InventoryCommandTest<ReservationPickUpPeriodExpired> {
+@DisplayName("MarkReservationExpiredCommandTest command should be interpreted by InventoryAggregate and")
+public class MarkReservationExpiredCommandTest extends InventoryCommandTest<MarkReservationExpired> {
 
     @Override
     @BeforeEach
@@ -48,31 +48,30 @@ public class ReservationPickUpPeriodExpiredCommandTest extends InventoryCommandT
     }
 
     @Test
-    @DisplayName("produce MarkReservationExpired event")
+    @DisplayName("produce ReservationPickUpPeriodExpired event")
     void produceEvent() {
         dispatchReserveBook();
 
-        final MarkReservationExpired reservationExpired = InventoryCommandFactory.markReservationExpiredInstance();
-        final List<? extends Message> messageList = dispatchCommand(aggregate,
-                                                                    envelopeOf(
-                                                                            reservationExpired));
-        assertNotNull(aggregate.getId());
+        final MarkReservationExpired markReservationExpired =
+                InventoryCommandFactory.markReservationExpiredInstance();
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(markReservationExpired));
         assertEquals(1, messageList.size());
         assertEquals(ReservationPickUpPeriodExpired.class, messageList.get(0)
                                                                       .getClass());
     }
 
     @Test
-    @DisplayName("mark reservation as expired")
+    @DisplayName("remove the expired reservation")
     void reservationPickUpPeriodExpired() {
         dispatchReserveBook();
 
-        final MarkReservationExpired reservationExpired = InventoryCommandFactory.markReservationExpiredInstance();
-
+        final MarkReservationExpired reservationExpired =
+                InventoryCommandFactory.markReservationExpiredInstance();
         dispatchCommand(aggregate, envelopeOf(reservationExpired));
-        assertEquals(0, aggregate.getDefaultState()
-                                 .getReservationsList()
-                                 .size());
+        final Inventory state = aggregate.getState();
+        final int reservationsCount = state.getReservationsCount();
+        assertEquals(0, reservationsCount);
     }
 
     void dispatchReserveBook() {

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/RejectionConstructorsTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/RejectionConstructorsTest.java
@@ -29,6 +29,12 @@ import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 public class RejectionConstructorsTest {
 
     @Test
+    @DisplayName("InventoryAggregateRejections has a private constructor")
+    void InventoryAggregateRejectionsHasPrivateConstructor() {
+        assertHasPrivateParameterlessCtor(InventoryAggregateRejections.class);
+    }
+
+    @Test
     @DisplayName("ReturnBookRejection has a private constructor")
     void ReturnBookRejectionHasPrivateConstructor() {
         assertHasPrivateParameterlessCtor(InventoryAggregateRejections.ReturnBookRejection.class);
@@ -41,20 +47,14 @@ public class RejectionConstructorsTest {
     }
 
     @Test
-    @DisplayName("InventoryAggregateRejections has a private constructor")
-    void InventoryAggregateRejectionsHasPrivateConstructor() {
-        assertHasPrivateParameterlessCtor(InventoryAggregateRejections.class);
+    @DisplayName("BorrowBookRejection has a private constructor")
+    void BorrowBookRejectionHasPrivateConstructor() {
+        assertHasPrivateParameterlessCtor(InventoryAggregateRejections.BorrowBookRejection.class);
     }
 
     @Test
     @DisplayName("BookAggregateRejections has a private constructor")
     void  BookAggregateRejectionsHasPrivateConstructor() {
         assertHasPrivateParameterlessCtor(BookAggregateRejections.class);
-    }
-
-    @Test
-    @DisplayName("BorrowBookRejection has a private constructor")
-    void BorrowBookRejectionHasPrivateConstructor() {
-        assertHasPrivateParameterlessCtor(InventoryAggregateRejections.BorrowBookRejection.class);
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReportLostBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReportLostBookCommandTest.java
@@ -22,10 +22,12 @@ package javaclasses.exlibris.c.inventory;
 
 import com.google.protobuf.Message;
 import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.InventoryItem;
+import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BookLost;
+import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.ReportLostBook;
-import javaclasses.exlibris.c.ReserveBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,17 +36,20 @@ import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.reportLostBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userEmailAddress1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Paul Ageyev
  */
-@DisplayName("ReportLostBookCommandTest command should be interpreted by InventoryAggregate and")
-public class ReportLostBookCommandTest extends InventoryCommandTest<ReserveBook> {
+@DisplayName("ReportLostBook command should be interpreted by InventoryAggregate and")
+public class ReportLostBookCommandTest extends InventoryCommandTest<ReportLostBook> {
 
     @Override
     @BeforeEach
@@ -55,13 +60,12 @@ public class ReportLostBookCommandTest extends InventoryCommandTest<ReserveBook>
     @Test
     @DisplayName("produce BookLost event")
     void produceEvent() {
-        dispatchAppendInventory();
+        borrowBook();
 
         final ReportLostBook reportLostBook = reportLostBookInstance();
 
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(reportLostBook));
-
         assertNotNull(aggregate.getId());
         assertEquals(1, messageList.size());
         assertEquals(BookLost.class, messageList.get(0)
@@ -75,22 +79,25 @@ public class ReportLostBookCommandTest extends InventoryCommandTest<ReserveBook>
     }
 
     @Test
-    @DisplayName("report for lost book")
+    @DisplayName("set item status as lost and remove absent loan.")
     void reportLostBook() {
-        dispatchAppendInventory();
+        borrowBook();
 
         final ReportLostBook reportLostBook = reportLostBookInstance();
         dispatchCommand(aggregate, envelopeOf(reportLostBook));
 
-        final Inventory currentInventory = aggregate.getState();
+        final Inventory state = aggregate.getState();
+        final InventoryItem lostItem = state.getInventoryItems(0);
 
-        assertEquals(true, currentInventory.getInventoryItemsList()
-                                           .get(0)
-                                           .getLost());
+        assertTrue(lostItem.getLost());
+        assertFalse(lostItem.getBorrowed());
+        assertEquals(UserId.getDefaultInstance(), lostItem.getUserId());
     }
 
-    private void dispatchAppendInventory() {
+    private void borrowBook() {
         final AppendInventory appendInventory = appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
+        final BorrowBook borrowBook = borrowBookInstance();
+        dispatchCommand(aggregate, envelopeOf(borrowBook));
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReportLostBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReportLostBookCommandTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.reportLostBookInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userEmailAddress1;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReservationPickUpPeriodExpiredCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReservationPickUpPeriodExpiredCommandTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.reservationPickUpPeriodInstanceExpired;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -53,7 +52,7 @@ public class ReservationPickUpPeriodExpiredCommandTest extends InventoryCommandT
     void produceEvent() {
         dispatchReserveBook();
 
-        final MarkReservationExpired reservationExpired = reservationPickUpPeriodInstanceExpired();
+        final MarkReservationExpired reservationExpired = InventoryCommandFactory.markReservationExpiredInstance();
         final List<? extends Message> messageList = dispatchCommand(aggregate,
                                                                     envelopeOf(
                                                                             reservationExpired));
@@ -68,7 +67,7 @@ public class ReservationPickUpPeriodExpiredCommandTest extends InventoryCommandT
     void reservationPickUpPeriodExpired() {
         dispatchReserveBook();
 
-        final MarkReservationExpired reservationExpired = reservationPickUpPeriodInstanceExpired();
+        final MarkReservationExpired reservationExpired = InventoryCommandFactory.markReservationExpiredInstance();
 
         dispatchCommand(aggregate, envelopeOf(reservationExpired));
         assertEquals(0, aggregate.getDefaultState()

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReserveBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReserveBookCommandTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.isbn62;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userEmailAddress1;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
@@ -132,7 +133,7 @@ public class ReserveBookCommandTest extends InventoryCommandTest<ReserveBook> {
         final AppendInventory appendInventory = appendInventoryInstance();
         dispatchCommand(aggregate, envelopeOf(appendInventory));
 
-        final BorrowBook borrowBook = borrowBookInstance(InventoryCommandFactory.inventoryId,
+        final BorrowBook borrowBook = borrowBookInstance(inventoryId,
                                                          InventoryCommandFactory.inventoryItemId,
                                                          InventoryCommandFactory.userId);
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReserveBookCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/ReserveBookCommandTest.java
@@ -31,6 +31,7 @@ import javaclasses.exlibris.c.ReservationAdded;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.rejection.BookAlreadyBorrowed;
 import javaclasses.exlibris.c.rejection.BookAlreadyReserved;
+import javaclasses.exlibris.c.rejection.CannotReserveAvailableBook;
 import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -92,7 +93,7 @@ public class ReserveBookCommandTest extends InventoryCommandTest<ReserveBook> {
     }
 
     @Test
-    @DisplayName("throw CannotReserveBook rejection upon " +
+    @DisplayName("throw BookAlreadyReserved rejection upon " +
             "an attempt reserve the book that is already reserved")
     void reserveBookTwice() {
         final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance();
@@ -114,7 +115,7 @@ public class ReserveBookCommandTest extends InventoryCommandTest<ReserveBook> {
     }
 
     @Test
-    @DisplayName("throw CannotReserveBook rejection upon " +
+    @DisplayName("throw BookAlreadyBorrowed rejection upon " +
             "an attempt reserve the book that is already borrowed")
     void notReserveBorrowedBook() {
         final AppendInventory appendInventory = appendInventoryInstance();
@@ -133,6 +134,29 @@ public class ReserveBookCommandTest extends InventoryCommandTest<ReserveBook> {
         assertThat(cause, instanceOf(BookAlreadyBorrowed.class));
 
         final BookAlreadyBorrowed rejection = (BookAlreadyBorrowed) cause;
+        final BookId actualBookId = rejection.getMessageThrown()
+                                             .getInventoryId()
+                                             .getBookId();
+        assertEquals(reserveBook.getInventoryId()
+                                .getBookId(), actualBookId);
+    }
+
+    @Test
+    @DisplayName("throw CannotReserveAvailableBook rejection upon " +
+            "an attempt reserve the book that is available for borrowing")
+    void notReserveAvailableBook() {
+        final AppendInventory appendInventory = appendInventoryInstance();
+        dispatchCommand(aggregate, envelopeOf(appendInventory));
+
+        final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance();
+        final Throwable t = assertThrows(Throwable.class,
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(reserveBook)));
+        final Throwable cause = Throwables.getRootCause(t);
+
+        assertThat(cause, instanceOf(CannotReserveAvailableBook.class));
+
+        final CannotReserveAvailableBook rejection = (CannotReserveAvailableBook) cause;
         final BookId actualBookId = rejection.getMessageThrown()
                                              .getInventoryId()
                                              .getBookId();

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/SatisfyReservationCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/SatisfyReservationCommandTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.inventory;
+
+import com.google.protobuf.Message;
+import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.Reservation;
+import javaclasses.exlibris.UserId;
+import javaclasses.exlibris.c.BookReadyToPickup;
+import javaclasses.exlibris.c.ReserveBook;
+import javaclasses.exlibris.c.SatisfyReservation;
+import javaclasses.exlibris.testdata.InventoryCommandFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.satisfyReservationInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Yegor Udovchenko
+ */
+@DisplayName("SatisfyReservation command should be interpreted by InventoryAggregate and")
+public class SatisfyReservationCommandTest extends InventoryCommandTest<SatisfyReservation> {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        dispatchReserveBook();
+    }
+
+    @Test
+    @DisplayName("produce BookReadyToPickup event")
+    void produceEvent() {
+        final SatisfyReservation satisfyReservation = satisfyReservationInstance();
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(satisfyReservation));
+
+        assertEquals(1, messageList.size());
+        assertEquals(BookReadyToPickup.class, messageList.get(0)
+                                                         .getClass());
+        // Pick up period. Seconds in two days.
+        final long OPEN_FOR_BORROW = 60 * 60 * 24 * 2;
+        final BookReadyToPickup bookReadyToPickup = (BookReadyToPickup) messageList.get(0);
+        final UserId forWhom = bookReadyToPickup.getForWhom();
+        final long whenBecame = bookReadyToPickup.getWhenBecameReadyToPickup()
+                                                 .getSeconds();
+        final long pickUpDeadline = bookReadyToPickup.getPickUpDeadline()
+                                                     .getSeconds();
+        assertEquals(whenBecame + OPEN_FOR_BORROW, pickUpDeadline);
+        assertEquals(userId, forWhom);
+    }
+
+    @Test
+    @DisplayName("set reservation as satisfied")
+    void setReservationSatisfied() {
+        final Inventory stateBefore = aggregate.getState();
+        final Reservation reservation = stateBefore.getReservations(0);
+        assertFalse(reservation.getIsSatisfied());
+
+        final SatisfyReservation satisfyReservation = satisfyReservationInstance();
+        dispatchCommand(aggregate, envelopeOf(satisfyReservation));
+
+        final Inventory stateAfter = aggregate.getState();
+        final Reservation reservationAfter = stateAfter.getReservations(0);
+        assertTrue(reservationAfter.getIsSatisfied());
+    }
+
+    private void dispatchReserveBook() {
+        final ReserveBook reserveBook = InventoryCommandFactory.reserveBookInstance();
+        dispatchCommand(aggregate, envelopeOf(reserveBook));
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/WriteBookOffCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/WriteBookOffCommandTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.isbn62;
 import static javaclasses.exlibris.testdata.InventoryCommandFactory.userEmailAddress1;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/api-java/src/test/java/javaclasses/exlibris/c/inventory/WriteBookOffCommandTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/inventory/WriteBookOffCommandTest.java
@@ -27,7 +27,7 @@ import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.InventoryDecreased;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.WriteBookOff;
-import javaclasses.exlibris.c.rejection.CannotWriteMissingBookOff;
+import javaclasses.exlibris.c.rejection.CannotWriteBookOff;
 import javaclasses.exlibris.testdata.InventoryCommandFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -119,6 +119,6 @@ public class WriteBookOffCommandTest extends InventoryCommandTest<ReserveBook> {
 
         final Throwable cause = Throwables.getRootCause(t);
 
-        assertThat(cause, instanceOf(CannotWriteMissingBookOff.class));
+        assertThat(cause, instanceOf(CannotWriteBookOff.class));
     }
 }

--- a/api-java/src/test/java/javaclasses/exlibris/c/procman/LoansExtensionProcmanTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/procman/LoansExtensionProcmanTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import io.spine.core.Command;
+import javaclasses.exlibris.Loan;
+import javaclasses.exlibris.LoanId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.protobuf.TypeConverter.toMessage;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markLoanOverdue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("LoansExtensionProcman should")
+public class LoansExtensionProcmanTest extends ProcessManagerTest {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    @DisplayName("react on ReservationAdded event and make first loan not allowed for extension.")
+    void reactOnReservationAddedMakesFirstLoanNotAllowedForExtension() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(reserveBookUser2, observer);
+
+        final LoanId loanId = getAggregateState().getLoans(0)
+                                                 .getLoanId();
+        final Command markLoanOverdueUser1Item1 =
+                requestFactory.createCommand(toMessage(markLoanOverdue(loanId, inventoryId)));
+        commandBus.post(markLoanOverdueUser1Item1, observer);
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+
+        commandBus.post(extendLoanPeriodUser1Item1, observer);
+        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on BookReadyToPickup event and make loans allowed for extension if necessary.")
+    void reactOnBookReturnedMakesAvailable() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(appendInventoryItem2, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(borrowBookUser2Item2, observer);
+        commandBus.post(reserveBookUser3, observer);
+
+        final Loan loanUser1Item1 = getAggregateState().getLoans(0);
+        final Loan loanUser2Item2 = getAggregateState().getLoans(1);
+        assertFalse(loanUser1Item1.getIsAllowedExtension());
+        assertTrue(loanUser2Item2.getIsAllowedExtension());
+
+        commandBus.post(returnBookUser2Item2, observer);
+        final Loan loanUser1Item1After = getAggregateState().getLoans(0);
+        assertTrue(loanUser1Item1After.getIsAllowedExtension());
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on ReservationCanceled event and make loans allowed for extension if necessary.")
+    void reactOnUnsatisfiedReservationCanceledEventAndAllowLoansExtension() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(reserveBookUser2, observer);
+
+        final Loan loanUser1Item1 = getAggregateState().getLoans(0);
+        assertFalse(loanUser1Item1.getIsAllowedExtension());
+
+        commandBus.post(cancelReservationUser2, observer);
+        final Loan loanUser1Item1After = getAggregateState().getLoans(0);
+        assertTrue(loanUser1Item1After.getIsAllowedExtension());
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/procman/ProcessManagerTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/procman/ProcessManagerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import com.google.common.base.Optional;
+import io.grpc.stub.StreamObserver;
+import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
+import io.spine.core.Command;
+import io.spine.grpc.StreamObservers;
+import io.spine.server.BoundedContext;
+import io.spine.server.commandbus.CommandBus;
+import io.spine.server.event.EventBus;
+import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.memory.InMemoryStorageFactory;
+import javaclasses.exlibris.Inventory;
+import javaclasses.exlibris.c.book.BookRepository;
+import javaclasses.exlibris.c.inventory.InventoryAggregate;
+import javaclasses.exlibris.c.inventory.InventoryRepository;
+import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
+import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.protobuf.TypeConverter.toMessage;
+import static io.spine.util.Exceptions.newIllegalStateException;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.cancelReservationInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.extendLoanPeriodInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId2;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markReservationExpiredInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId3;
+
+public class ProcessManagerTest {
+    /** The name of the test {@code BoundedContext}. */
+    private static final String NAME = "ExlibrisProcmanTestBoundedContext";
+
+    private static final StorageFactory IN_MEMORY_FACTORY =
+            InMemoryStorageFactory.newInstance(BoundedContext.newName(NAME), false);
+
+    final TestActorRequestFactory requestFactory =
+            TestActorRequestFactory.newInstance(getClass());
+
+    final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
+
+    final Command appendInventoryItem1 =
+            requestFactory.createCommand(toMessage(appendInventoryInstance()));
+
+    final Command appendInventoryItem2 =
+            requestFactory.createCommand(toMessage(appendInventoryInstance(inventoryId,
+                                                                           inventoryItemId2,
+                                                                           userId)));
+    final Command borrowBookUser1Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance()));
+
+    final Command borrowBookUser2Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
+                                                                      inventoryItemId,
+                                                                      userId2)));
+    final Command borrowBookUser2Item2 =
+            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
+                                                                      inventoryItemId2,
+                                                                      userId2)));
+    final Command borrowBookUser3Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
+                                                                      inventoryItemId,
+                                                                      userId3)));
+
+    final Command returnBookUser1Item1 =
+            requestFactory.createCommand(toMessage(returnBookInstance()));
+
+    final Command returnBookUser2Item2 =
+            requestFactory.createCommand(toMessage(returnBookInstance(inventoryId,
+                                                                      inventoryItemId2,
+                                                                      userId2)));
+    final Command reserveBookUser2 =
+            requestFactory.createCommand(toMessage(reserveBookInstance(userId2,
+                                                                       inventoryId)));
+
+    final Command reserveBookUser3 =
+            requestFactory.createCommand(toMessage(reserveBookInstance(userId3,
+                                                                       inventoryId)));
+
+    final Command cancelReservationUser2 =
+            requestFactory.createCommand(toMessage(cancelReservationInstance(inventoryId,
+                                                                             userId2)));
+
+    final Command expireReservationUser3 =
+            requestFactory.createCommand(toMessage(markReservationExpiredInstance(inventoryId,
+                                                                                  userId3)));
+
+    final Command extendLoanPeriodUser1Item1 =
+            requestFactory.createCommand(toMessage(extendLoanPeriodInstance()));
+
+    protected BoundedContext boundedContext;
+    protected CommandBus commandBus;
+    protected StreamObserver<Ack> observer;
+    protected BookRejectionsSubscriber bookRejectionsSubscriber;
+    protected InventoryRejectionsSubscriber inventoryRejectionsSubscriber;
+
+    public void setUp() {
+        InventoryRepository.setNewInstance();
+        boundedContext = createTestContext();
+        commandBus = boundedContext.getCommandBus();
+        observer = StreamObservers.noOpObserver();
+        bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+    }
+
+    /**
+     * Creates a new instance of the {@link BoundedContext}
+     * using the specified {@link StorageFactory}.
+     *
+     * @return the bounded context created with the storage factory
+     */
+    private static BoundedContext createTestContext() {
+
+        final BookRepository bookRepository = new BookRepository();
+        final InventoryRepository inventoryRepository = InventoryRepository.getRepository();
+        final ReservationQueueProcmanRepository reservationQueueRepository = new ReservationQueueProcmanRepository();
+        final LoansExtensionProcmanRepository loansExtensionRepository = new LoansExtensionProcmanRepository();
+
+        final EventBus.Builder eventBus = createEventBus(IN_MEMORY_FACTORY);
+
+        final BoundedContext boundedContext = createBoundedContext(eventBus);
+
+        boundedContext.register(bookRepository);
+        boundedContext.register(inventoryRepository);
+        boundedContext.register(reservationQueueRepository);
+        boundedContext.register(loansExtensionRepository);
+        return boundedContext;
+    }
+
+    private static EventBus.Builder createEventBus(StorageFactory storageFactory) {
+        final EventBus.Builder eventBus = EventBus.newBuilder()
+                                                  .setStorageFactory(storageFactory);
+        return eventBus;
+    }
+
+    private static BoundedContext createBoundedContext(EventBus.Builder eventBus) {
+        checkNotNull(eventBus);
+
+        final Optional<StorageFactory> storageFactory = eventBus.getStorageFactory();
+
+        if (!storageFactory.isPresent()) {
+            throw newIllegalStateException("EventBus does not specify a StorageFactory.");
+        }
+
+        return BoundedContext.newBuilder()
+                             .setStorageFactorySupplier(storageFactory::get)
+                             .setName(NAME)
+                             .setEventBus(eventBus)
+                             .build();
+    }
+
+    protected Inventory getAggregateState() {
+        final Optional<InventoryAggregate> aggregateOptional = InventoryRepository.getRepository()
+                                                                                  .find(inventoryId);
+        return aggregateOptional.isPresent() ? aggregateOptional.get()
+                                                                .getState() : null;
+    }
+}

--- a/api-java/src/test/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanTest.java
@@ -20,101 +20,20 @@
 
 package javaclasses.exlibris.c.procman;
 
-import com.google.protobuf.Message;
-import io.grpc.stub.StreamObserver;
-import io.spine.client.TestActorRequestFactory;
-import io.spine.core.Ack;
-import io.spine.core.Command;
-import io.spine.grpc.StreamObservers;
-import io.spine.server.BoundedContext;
-import io.spine.server.commandbus.CommandBus;
-import javaclasses.exlibris.BoundedContexts;
-import javaclasses.exlibris.c.inventory.InventoryCommandTest;
-import javaclasses.exlibris.c.inventory.InventoryRepository;
-import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
-import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
+import javaclasses.exlibris.Reservation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.protobuf.TypeConverter.toMessage;
-import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.cancelReservationInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.markReservationExpiredInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
-import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId3;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("ReservationQueueProcman should")
-public class ReservationQueueProcmanTest extends InventoryCommandTest<Message> {
-    private final TestActorRequestFactory requestFactory =
-            TestActorRequestFactory.newInstance(getClass());
-
-    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
-
-    private final Command appendInventoryItem1 =
-            requestFactory.createCommand(toMessage(appendInventoryInstance()));
-
-    private final Command borrowBookUser1Item1 =
-            requestFactory.createCommand(toMessage(borrowBookInstance()));
-
-    private final Command borrowBookUser2Item1 =
-            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
-                                                                      inventoryItemId,
-                                                                      userId2)));
-
-    private final Command borrowBookUser3Item1 =
-            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
-                                                                      inventoryItemId,
-                                                                      userId3)));
-
-    private final Command returnBookUser1Item1 =
-            requestFactory.createCommand(toMessage(returnBookInstance()));
-
-    private final Command reserveBookUser2 =
-            requestFactory.createCommand(toMessage(reserveBookInstance(userId2,
-                                                                       inventoryId)));
-
-    private final Command reserveBookUser3 =
-            requestFactory.createCommand(toMessage(reserveBookInstance(userId3,
-                                                                       inventoryId)));
-
-    private final Command cancelReservationUser2 =
-            requestFactory.createCommand(toMessage(cancelReservationInstance(inventoryId,
-                                                                             userId2)));
-
-    private final Command expireReservationUser3 =
-            requestFactory.createCommand(toMessage(markReservationExpiredInstance(inventoryId,
-                                                                                  userId3)));
-
-    private BoundedContext boundedContext;
-    private CommandBus commandBus;
-    private StreamObserver<Ack> observer;
-    private BookRejectionsSubscriber bookRejectionsSubscriber;
-    private InventoryRejectionsSubscriber inventoryRejectionsSubscriber;
-
+public class ReservationQueueProcmanTest extends ProcessManagerTest {
     @Override
     @BeforeEach
     public void setUp() {
         super.setUp();
-        InventoryRepository.setNewInstance();
-        boundedContext = BoundedContexts.create();
-        commandBus = boundedContext.getCommandBus();
-        observer = StreamObservers.noOpObserver();
-        bookRejectionsSubscriber = new BookRejectionsSubscriber();
-        inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
-        boundedContext.getRejectionBus()
-                      .register(bookRejectionsSubscriber);
-        boundedContext.getRejectionBus()
-                      .register(inventoryRejectionsSubscriber);
-        commandBus.post(addBook, observer);
     }
 
     @Test
@@ -137,6 +56,8 @@ public class ReservationQueueProcmanTest extends InventoryCommandTest<Message> {
         commandBus.post(returnBookUser1Item1, observer);
         commandBus.post(borrowBookUser1Item1, observer);
 
+        final Reservation reservation = getAggregateState().getReservations(0);
+        assertTrue(reservation.getIsSatisfied());
         assertTrue(inventoryRejectionsSubscriber.wasCalled());
     }
 

--- a/api-java/src/test/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanTest.java
+++ b/api-java/src/test/java/javaclasses/exlibris/c/procman/ReservationQueueProcmanTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javaclasses.exlibris.c.procman;
+
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
+import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
+import io.spine.core.Command;
+import io.spine.grpc.StreamObservers;
+import io.spine.server.BoundedContext;
+import io.spine.server.commandbus.CommandBus;
+import javaclasses.exlibris.BoundedContexts;
+import javaclasses.exlibris.c.inventory.InventoryCommandTest;
+import javaclasses.exlibris.c.inventory.InventoryRepository;
+import javaclasses.exlibris.testdata.BookRejectionsSubscriber;
+import javaclasses.exlibris.testdata.InventoryRejectionsSubscriber;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.protobuf.TypeConverter.toMessage;
+import static javaclasses.exlibris.testdata.BookCommandFactory.createBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.appendInventoryInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.borrowBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.cancelReservationInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.inventoryItemId;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.markReservationExpiredInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.reserveBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.returnBookInstance;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId2;
+import static javaclasses.exlibris.testdata.InventoryCommandFactory.userId3;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ReservationQueueProcman should")
+public class ReservationQueueProcmanTest extends InventoryCommandTest<Message> {
+    private final TestActorRequestFactory requestFactory =
+            TestActorRequestFactory.newInstance(getClass());
+
+    private final Command addBook = requestFactory.createCommand(toMessage(createBookInstance()));
+
+    private final Command appendInventoryItem1 =
+            requestFactory.createCommand(toMessage(appendInventoryInstance()));
+
+    private final Command borrowBookUser1Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance()));
+
+    private final Command borrowBookUser2Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
+                                                                      inventoryItemId,
+                                                                      userId2)));
+
+    private final Command borrowBookUser3Item1 =
+            requestFactory.createCommand(toMessage(borrowBookInstance(inventoryId,
+                                                                      inventoryItemId,
+                                                                      userId3)));
+
+    private final Command returnBookUser1Item1 =
+            requestFactory.createCommand(toMessage(returnBookInstance()));
+
+    private final Command reserveBookUser2 =
+            requestFactory.createCommand(toMessage(reserveBookInstance(userId2,
+                                                                       inventoryId)));
+
+    private final Command reserveBookUser3 =
+            requestFactory.createCommand(toMessage(reserveBookInstance(userId3,
+                                                                       inventoryId)));
+
+    private final Command cancelReservationUser2 =
+            requestFactory.createCommand(toMessage(cancelReservationInstance(inventoryId,
+                                                                             userId2)));
+
+    private final Command expireReservationUser3 =
+            requestFactory.createCommand(toMessage(markReservationExpiredInstance(inventoryId,
+                                                                                  userId3)));
+
+    private BoundedContext boundedContext;
+    private CommandBus commandBus;
+    private StreamObserver<Ack> observer;
+    private BookRejectionsSubscriber bookRejectionsSubscriber;
+    private InventoryRejectionsSubscriber inventoryRejectionsSubscriber;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        InventoryRepository.setNewInstance();
+        boundedContext = BoundedContexts.create();
+        commandBus = boundedContext.getCommandBus();
+        observer = StreamObservers.noOpObserver();
+        bookRejectionsSubscriber = new BookRejectionsSubscriber();
+        inventoryRejectionsSubscriber = new InventoryRejectionsSubscriber();
+        boundedContext.getRejectionBus()
+                      .register(bookRejectionsSubscriber);
+        boundedContext.getRejectionBus()
+                      .register(inventoryRejectionsSubscriber);
+        commandBus.post(addBook, observer);
+    }
+
+    @Test
+    @DisplayName("react on book returned event and make book available for borrowing.")
+    void reactOnBookReturnedMakesAvailable() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(returnBookUser1Item1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on book returned event and make book ready to pick up for next in reservation queue.")
+    void reactOnBookReturnedMakesReadyToPickUp() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(reserveBookUser2, observer);
+        commandBus.post(returnBookUser1Item1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+
+        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on reservation canceled event and make book available for borrowing.")
+    void reactOnCancelReservationMakesBookAvailable() {
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+        commandBus.post(reserveBookUser2, observer);
+        commandBus.post(returnBookUser1Item1, observer);
+        commandBus.post(cancelReservationUser2, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on reservation canceled event and make book ready to pick up for next in reservation queue.")
+    void reactOnCancelReservationMakesReadyToPickUp() {
+        commandBus.post(reserveBookUser2, observer);
+        commandBus.post(reserveBookUser3, observer);
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(cancelReservationUser2, observer);
+        commandBus.post(borrowBookUser3Item1, observer);
+
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on reservation pickup period expired event and make book available for borrowing.")
+    void reactOnReservationExpiredMakesBookAvailable() {
+        commandBus.post(reserveBookUser3, observer);
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(expireReservationUser3, observer);
+        commandBus.post(reserveBookUser2, observer);
+
+        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+    }
+
+    @Test
+    @DisplayName("react on reservation pickup period expired event and make book ready to pick up for next in reservation queue.")
+    void reactOnReservationExpiredMakesReadyToPickUp() {
+        commandBus.post(reserveBookUser3, observer);
+        commandBus.post(appendInventoryItem1, observer);
+        commandBus.post(reserveBookUser2, observer);
+        commandBus.post(expireReservationUser3, observer);
+        commandBus.post(borrowBookUser1Item1, observer);
+
+        assertTrue(inventoryRejectionsSubscriber.wasCalled());
+        inventoryRejectionsSubscriber.clear();
+
+        commandBus.post(borrowBookUser2Item1, observer);
+        assertFalse(inventoryRejectionsSubscriber.wasCalled());
+    }
+}

--- a/model/src/main/proto/javaclasses/exlibris/c/commands.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/commands.proto
@@ -264,15 +264,19 @@ message WriteBookOff {
     UserId librarian_id = 4;
 }
 
+// An attempt to mark corresponding loans as allowed for extension.
+//
 message AllowLoansExtension {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // The collection of users' identifiers whos loans became not allowed for an extension.
+    // The collection of users' identifiers whos loans became allowed for an extension.
     repeated UserId borrowers = 2;
 }
 
+// An attempt to mark corresponding loans as forbidden for extension.
+//
 message ForbidLoansExtension {
 
     // The identifier of an inventory.
@@ -282,6 +286,8 @@ message ForbidLoansExtension {
     repeated UserId borrowers = 2;
 }
 
+// An attempt to satisfy reservation for the specific user.
+//
 message SatisfyReservation {
 
     // The identifier of an inventory.
@@ -291,6 +297,8 @@ message SatisfyReservation {
     UserId user_id = 2;
 }
 
+// An attempt to increase available for borrowing books count.
+//
 message MarkBookAsAvailable {
 
     // The identifier of an inventory.

--- a/model/src/main/proto/javaclasses/exlibris/c/commands.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/commands.proto
@@ -268,12 +268,18 @@ message AllowLoansExtension {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
+
+    // The collection of users' identifiers whos loans became not allowed for an extension.
+    repeated UserId borrowers = 2;
 }
 
 message ForbidLoansExtension {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
+
+    // The collection of users' identifiers whos loans became not allowed for an extension.
+    repeated UserId borrowers = 2;
 }
 
 message SatisfyReservation {

--- a/model/src/main/proto/javaclasses/exlibris/c/commands.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/commands.proto
@@ -108,11 +108,8 @@ message AppendInventory {
     // The identifier of an added item.
     InventoryItemId inventory_item_id = 2;
 
-    // Optional field: exists when book has a RFID mark.
-    Rfid rfid = 3;
-
     // Who tries to append.
-    UserId librarian_id = 4;
+    UserId librarian_id = 3;
 }
 
 // An attempt to borrow a book.

--- a/model/src/main/proto/javaclasses/exlibris/c/commands.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/commands.proto
@@ -251,7 +251,7 @@ message ReportLostBook {
 //
 message WriteBookOff {
 
-    // The identifier of an inventory..
+    // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
     // The book that is planned to write off.
@@ -262,4 +262,31 @@ message WriteBookOff {
 
     // Who tries to write a book off.
     UserId librarian_id = 4;
+}
+
+message AllowLoansExtension {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+}
+
+message ForbidLoansExtension {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+}
+
+message SatisfyReservation {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // For whom reservation should be satisfied.
+    UserId user_id = 2;
+}
+
+message MarkBookAsAvailable {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
 }

--- a/model/src/main/proto/javaclasses/exlibris/c/commands.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/commands.proto
@@ -172,7 +172,7 @@ message ExtendLoanPeriod {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // The loan that is planned to extend.
+    // The identifier of a loan that is planned to extend.
     LoanId loan_id = 2;
 
     // Who extends the loan.
@@ -187,6 +187,17 @@ message MarkLoanOverdue {
     InventoryId inventory_id = 1;
 
     // The loan that is overdue.
+    LoanId loan_id = 2;
+}
+
+//  Marks the loan period as should return soon.
+//
+message MarkLoanShouldReturnSoon {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // The identifier of a loan which period runs out.
     LoanId loan_id = 2;
 }
 

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -89,7 +89,7 @@ message BookBecameAvailable {
 
 // An event fired when a book is available for a user to take it.
 //
-// Appears when an inventory appended or a book returned.
+// Appears when an inventory appended or a book returned or someone canceles his reservation.
 //
 // In 2 days this opportunity disappears and a reservation expires.
 //
@@ -110,9 +110,6 @@ message BookReadyToPickup {
 
 // An event fired when a user reserves a book.
 //
-// If a queue on book exists then user will be added to the queue.
-// Else if book is available then user has 2 days to borrow book.
-//
 message ReservationAdded {
 
     // The identifier of an inventory.
@@ -128,7 +125,7 @@ message ReservationAdded {
     google.protobuf.Timestamp when_created = 4;
 }
 
-// An event fired when user borrows book.
+// An event fired when a user borrows a book.
 //
 // Triggers 'reservation became loan' if the book was reserved.
 //

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -335,6 +335,9 @@ message ReservationCanceled {
 
     // The time when user canceled a reservation.
     google.protobuf.Timestamp when_canceled = 3;
+
+    // Shows whether the canceled reservation was satisfied or not.
+    bool was_satisfied = 4;
 }
 
 // An event fired when a librarian decreases a current inventory.

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -149,7 +149,7 @@ message BookBorrowed {
     // Who borrowed a book.
     UserId who_borrowed = 3;
 
-    // The loan period.
+    // The loan idenifier.
     LoanId loan_id = 4;
 
     // In library items count
@@ -157,6 +157,9 @@ message BookBorrowed {
 
     // The time when user borrowed a book.
     google.protobuf.Timestamp when_borrowed = 6;
+
+    // The time when the loan becomes overdue.
+    google.protobuf.Timestamp when_due = 7;
 }
 
 // An event when a reservation was successfully finished.
@@ -301,8 +304,11 @@ message BookReturned {
     // Who returned a book.
     UserId who_returned = 3;
 
+    // The loan idenifier.
+    LoanId loan_id = 4;
+
     // The timestamp when user returned a book.
-    google.protobuf.Timestamp when_returned = 4;
+    google.protobuf.Timestamp when_returned = 5;
 }
 
 // An event fired when an user lost a borrowed book.

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -118,8 +118,8 @@ message ReservationAdded {
     // Who reserved a book.
     UserId for_whom_reserved = 2;
 
-    // The date when the book is expected to become ready to pick up.
-    spine.time.LocalDate when_expected = 3;
+    // The estimated time when the book becomes ready to pick up.
+    google.protobuf.Timestamp when_expected = 3;
 
     // The time when the reservation was added.
     google.protobuf.Timestamp when_created = 4;

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -80,14 +80,11 @@ message BookBecameAvailable {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // The item which became available.
-    InventoryItemId inventory_item_id = 2;
-
     // In library items count
-    int32 in_library_count = 3;
+    int32 in_library_count = 2;
 
     // When book became available.
-    google.protobuf.Timestamp when_became_available = 4;
+    google.protobuf.Timestamp when_became_available = 3;
 }
 
 // An event fired when a book is available for a user to take it.
@@ -101,17 +98,14 @@ message BookReadyToPickup {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // The identifier of an inventory item which became ready to pickup.
-    InventoryItemId inventory_item_id = 2;
-
     // Who can take this book during 2 days.
-    UserId for_whom = 3;
+    UserId for_whom = 2;
 
     // When a book became ready to pickup.
-    google.protobuf.Timestamp when_became_ready_to_pickup = 4;
+    google.protobuf.Timestamp when_became_ready_to_pickup = 3;
 
     // The pickup deadline of a book.
-    google.protobuf.Timestamp pick_up_deadline = 5;
+    google.protobuf.Timestamp pick_up_deadline = 4;
 }
 
 // An event fired when a user reserves a book.

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -30,6 +30,7 @@ option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/time/time.proto";
 import "javaclasses/exlibris/identifiers.proto";
 import "javaclasses/exlibris/values.proto";
 import "google/protobuf/timestamp.proto";
@@ -59,8 +60,8 @@ message InventoryAppended {
     // The newly created item.
     InventoryItemId inventory_item_id = 2;
 
-    // Optional field: exists when book has RFID mark.
-    Rfid rfid = 3;
+    // The QR-code of an inventory item.
+    QRcodeURL qr_code_url = 3;
 
     // Who appended.
     UserId librarian_id = 4;
@@ -69,7 +70,8 @@ message InventoryAppended {
     google.protobuf.Timestamp when_appended = 5;
 }
 
-// The event appears when either an inventory appended or a book returned and there is no reservation.
+// The event appears when either an inventory appended, a book returned and there is no reservation,
+// a ready to pick up reservation was canceled and there are no more unsatisfied reservations.
 //
 // A book becomes public available.
 //
@@ -81,8 +83,11 @@ message BookBecameAvailable {
     // The item which became available.
     InventoryItemId inventory_item_id = 2;
 
+    // In library items count
+    int32 in_library_count = 3;
+
     // When book became available.
-    google.protobuf.Timestamp when_became_available = 3;
+    google.protobuf.Timestamp when_became_available = 4;
 }
 
 // An event fired when a book is available for a user to take it.
@@ -122,8 +127,11 @@ message ReservationAdded {
     // Who reserved a book.
     UserId for_whom_reserved = 2;
 
+    // The date when the book is expected to become ready to pick up.
+    spine.time.LocalDate when_expected = 3;
+
     // The time when the reservation was added.
-    google.protobuf.Timestamp when_created = 3;
+    google.protobuf.Timestamp when_created = 4;
 }
 
 // An event fired when user borrows book.
@@ -144,8 +152,11 @@ message BookBorrowed {
     // The loan period.
     LoanId loan_id = 4;
 
+    // In library items count
+    int32 in_library_count = 5;
+
     // The time when user borrowed a book.
-    google.protobuf.Timestamp when_borrowed = 5;
+    google.protobuf.Timestamp when_borrowed = 6;
 }
 
 // An event when a reservation was successfully finished.
@@ -178,8 +189,14 @@ message LoanBecameOverdue {
     // The identifier of a loan.
     LoanId loan_id = 4;
 
+    // Shows whether it is allowed to extend loan period.
+    //
+    // Depends on the state of the reservations query in the inventory aggregate.
+    //
+    bool is_allowed_extension = 5;
+
     // The time when a loan became overdue.
-    google.protobuf.Timestamp when_became_overdue = 5;
+    google.protobuf.Timestamp when_became_overdue = 6;
 }
 
 // An event fired when a user's loan period time runs out.
@@ -198,8 +215,14 @@ message LoanBecameShouldReturnSoon {
     // The identifier of a loan.
     LoanId loan_id = 4;
 
-    // The time when a loan became overdue.
-    google.protobuf.Timestamp when_became_should_return_soon = 5;
+    // Shows whether it is allowed to extend loan period.
+    //
+    // Depends on the state of the reservations query in the inventory aggregate.
+    //
+    bool is_allowed_extension = 5;
+
+    // The time when a loan became should return soon.
+    google.protobuf.Timestamp when_became_should_return_soon = 6;
 }
 
 // An event fired when user successfully extended his loan period.
@@ -238,10 +261,10 @@ message LoansBecameNotAllowedForExtension {
     InventoryId inventory_id = 1;
 
     // The collection of users' identifiers whos loans became not allowed for an extension.
-    repeated UserId borrowers = 3;
+    repeated UserId borrowers = 2;
 
     // The time when became not allowed.
-    google.protobuf.Timestamp when_became = 7;
+    google.protobuf.Timestamp when_became = 3;
 }
 
 // An event fired when the book reservations become satisfied or canceled
@@ -255,10 +278,10 @@ message LoansBecameExtensionAllowed {
     InventoryId inventory_id = 1;
 
     // The collection of users' identifiers whos loans became allowed for an extension.
-    repeated UserId borrowers = 3;
+    repeated UserId borrowers = 2;
 
     // The time when became allowed.
-    google.protobuf.Timestamp when_became = 7;
+    google.protobuf.Timestamp when_became = 3;
 }
 
 // An event fired when a user returns a book.
@@ -335,8 +358,11 @@ message InventoryDecreased {
     // The time when inventory was decreased.
     google.protobuf.Timestamp when_decreased = 4;
 
+    // In library items count
+    int32 in_library_count = 5;
+
     // A book can be lost or outdated.
-    WriteOffReason write_off_reason = 5;
+    WriteOffReason write_off_reason = 6;
 }
 
 // An event fired when user had 2 days to take the book but he didn't.

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -80,8 +80,8 @@ message BookBecameAvailable {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // In library items count
-    int32 in_library_count = 2;
+    // The number of public available books.
+    int32 available_books_count = 2;
 
     // When book became available.
     google.protobuf.Timestamp when_became_available = 3;
@@ -146,8 +146,8 @@ message BookBorrowed {
     // The loan idenifier.
     LoanId loan_id = 4;
 
-    // In library items count
-    int32 in_library_count = 5;
+    // The number of public available books.
+    int32 available_books_count = 5;
 
     // The time when user borrowed a book.
     google.protobuf.Timestamp when_borrowed = 6;
@@ -358,8 +358,8 @@ message InventoryDecreased {
     // The time when inventory was decreased.
     google.protobuf.Timestamp when_decreased = 4;
 
-    // In library items count
-    int32 in_library_count = 5;
+    // The number of public available books.
+    int32 available_books_count = 5;
 
     // A book can be lost or outdated.
     WriteOffReason write_off_reason = 6;

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -169,11 +169,37 @@ message LoanBecameOverdue {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // The identifier of a loan.
-    LoanId loan_id = 2;
+    // The identifier of an item.
+    InventoryItemId inventory_item_id = 2;
 
-    // The date when a book was expected, so an overdue period can be calculated.
-    google.protobuf.Timestamp when_expected = 3;
+    // The loan owner.
+    UserId user_id = 3;
+
+    // The identifier of a loan.
+    LoanId loan_id = 4;
+
+    // The time when a loan became overdue.
+    google.protobuf.Timestamp when_became_overdue = 5;
+}
+
+// An event fired when a user's loan period time runs out.
+//
+message LoanBecameShouldReturnSoon {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // The identifier of an item.
+    InventoryItemId inventory_item_id = 2;
+
+    // The loan owner.
+    UserId user_id = 3;
+
+    // The identifier of a loan.
+    LoanId loan_id = 4;
+
+    // The time when a loan became overdue.
+    google.protobuf.Timestamp when_became_should_return_soon = 5;
 }
 
 // An event fired when user successfully extended his loan period.
@@ -189,11 +215,50 @@ message LoanPeriodExtended {
     // Who extended.
     UserId user_id = 3;
 
+    // The identifier of an item.
+    InventoryItemId inventory_item_id = 4;
+
     // The timestamp of a previous due date.
-    google.protobuf.Timestamp previous_due_date = 4;
+    google.protobuf.Timestamp previous_due_date = 5;
 
     // The timestamp of a new due date.
-    google.protobuf.Timestamp new_due_date = 5;
+    google.protobuf.Timestamp new_due_date = 6;
+
+    // The time when a loan period was extended.
+    google.protobuf.Timestamp when_extended = 7;
+}
+
+// An event fired when the book was reserved and this reservation was the first in the list.
+//
+// All recent loans of the specified book become not allowed for extension.
+//
+message LoansBecameNotAllowedForExtension {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // The collection of users' identifiers whos loans became not allowed for an extension.
+    repeated UserId borrowers = 3;
+
+    // The time when became not allowed.
+    google.protobuf.Timestamp when_became = 7;
+}
+
+// An event fired when the book reservations become satisfied or canceled
+// and there are no more active reservations for this book.
+//
+// All recent loans of the specified book become allowed for extension.
+//
+message LoansBecameExtensionAllowed {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // The collection of users' identifiers whos loans became allowed for an extension.
+    repeated UserId borrowers = 3;
+
+    // The time when became allowed.
+    google.protobuf.Timestamp when_became = 7;
 }
 
 // An event fired when a user returns a book.

--- a/model/src/main/proto/javaclasses/exlibris/c/events.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/events.proto
@@ -255,7 +255,7 @@ message LoanPeriodExtended {
 //
 // All recent loans of the specified book become not allowed for extension.
 //
-message LoansBecameNotAllowedForExtension {
+message LoansExtensionForbidden {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
@@ -272,7 +272,7 @@ message LoansBecameNotAllowedForExtension {
 //
 // All recent loans of the specified book become allowed for extension.
 //
-message LoansBecameExtensionAllowed {
+message LoansExtensionAllowed {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;

--- a/model/src/main/proto/javaclasses/exlibris/c/rejections.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/rejections.proto
@@ -191,7 +191,7 @@ message CannotCancelMissingReservation {
 
 // Rejection when a librarian tries to write a missing book off.
 //
-message CannotWriteMissingBookOff {
+message CannotWriteBookOff {
 
     // The identifier of an inventory.
     InventoryId inventory_id = 1;

--- a/model/src/main/proto/javaclasses/exlibris/c/rejections.proto
+++ b/model/src/main/proto/javaclasses/exlibris/c/rejections.proto
@@ -103,10 +103,10 @@ message BookAlreadyReserved {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // Who tried to borrow a book.
+    // Who tried to reserve a book.
     UserId user_id = 2;
 
-    // The time when a user tried to borrow a book.
+    // The time when a user tried to reserve a book.
     google.protobuf.Timestamp when_rejected = 3;
 }
 
@@ -117,7 +117,21 @@ message BookAlreadyBorrowed {
     // The identifier of an inventory.
     InventoryId inventory_id = 1;
 
-    // Who tried to borrow a book.
+    // Who tried to reserve a book.
+    UserId user_id = 2;
+
+    // The time when a user tried to reserve a book.
+    google.protobuf.Timestamp when_rejected = 3;
+}
+
+// Rejection when a user tries to reserve a book that is available to borrow.
+//
+message CannotReserveAvailableBook {
+
+    // The identifier of an inventory.
+    InventoryId inventory_id = 1;
+
+    // Who tried to reserve a book.
     UserId user_id = 2;
 
     // The time when a user tried to borrow a book.

--- a/model/src/main/proto/javaclasses/exlibris/identifiers.proto
+++ b/model/src/main/proto/javaclasses/exlibris/identifiers.proto
@@ -92,3 +92,12 @@ message ReservationQueueId {
     //
     string value = 1;
 }
+
+// The identifier of a loans extension process manager.
+//
+message LoansExtensionId {
+
+    // String representation of UUID.
+    //
+    string value = 1;
+}

--- a/model/src/main/proto/javaclasses/exlibris/identifiers.proto
+++ b/model/src/main/proto/javaclasses/exlibris/identifiers.proto
@@ -83,3 +83,12 @@ message LoanId {
     // Maybe `currentTimeMillis`.
     int64 value = 1;
 }
+
+// The identifier of a reservation queue process manager.
+//
+message ReservationQueueId {
+
+    // String representation of UUID.
+    //
+    string value = 1;
+}

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -84,10 +84,16 @@ message InventoryItem {
         bool lost = 4;
     }
 
+    // The QR-code of an inventory item.
+    QRcodeURL qr_code_url = 5;
+
+    // The RFID mark of an inventory item.
+    Rfid rfid = 6;
+
     // The user who is related to the book.
     //
     // Is defined when a book is 'borrowed' or 'lost'
-    UserId user_id = 5;
+    UserId user_id = 7;
 }
 
 // The model of a reservation.

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -118,11 +118,17 @@ message Loan {
     UserId who_borrowed = 3;
 
     // The loan status.
-    bool overdue = 4;
+    LoanStatus status = 4;
 
     // The time when a book was borrowed.
     google.protobuf.Timestamp when_taken = 5;
 
     // The time when a book should be returned.
     google.protobuf.Timestamp when_due = 6;
+
+    // Shows whether it is allowed to extend loan period.
+    //
+    // Depends on the state of the reservations query in the inventory aggregate.
+    //
+    bool is_allowed_extension = 7;
 }

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -92,7 +92,7 @@ message InventoryItem {
 
     // The user who is related to the book.
     //
-    // Is defined when a book is 'borrowed' or 'lost'
+    // Is defined when a book is 'borrowed' or 'lost'.
     UserId user_id = 7;
 }
 
@@ -147,16 +147,30 @@ message Loan {
 
 // The model of a reservation queue process manager.
 //
+// Reacts on all aggregate events that signalize the available inventory item occurs in
+// the inventory. As a result of reacting to those events, process manager decides the
+// inventory item function: to become available for free borrowing(dispatch MarkBookAsAvailable)
+// or to satisfy someone's reservation(dispatch SatisfyReservation).
+//
+// The reservation choice depends on its position in the reservations list in the aggregate state.
+// The eldest one is chosen.
+//
 message ReservationQueue {
 
-    // The identifier of a process manager
+    // The identifier of a process manager.
     ReservationQueueId id = 1;
 }
 
 // The model of a loans extension process manager.
 //
+// Enters into work when the reservation list changes its state:
+// ReservationAdded, BookReadyToPickup, ReservationCanceled
+//
+// As a result of reacting to those events, process manager tries to provide each unsatisfied
+// reservation with one forbidden for extension loan.
+//
 message LoansExtension {
 
-    // The identifier of a process manager
+    // The identifier of a process manager.
     LoansExtensionId id = 1;
 }

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -100,8 +100,11 @@ message Reservation {
     // The user who reserved a book.
     UserId who_reserved = 2;
 
+    // Indicates is reserved book ready to pick up or not.
+    bool is_satisfied = 3;
+
     // The time when a book was reserved.
-    google.protobuf.Timestamp when_created = 3;
+    google.protobuf.Timestamp when_created = 4;
 }
 
 // The model of a loan.

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -111,6 +111,9 @@ message Reservation {
 
     // The time when a book was reserved.
     google.protobuf.Timestamp when_created = 4;
+
+    // The time when a reservation might be satisfied.
+    google.protobuf.Timestamp when_expected = 5;
 }
 
 // The model of a loan.

--- a/model/src/main/proto/javaclasses/exlibris/model.proto
+++ b/model/src/main/proto/javaclasses/exlibris/model.proto
@@ -141,3 +141,19 @@ message Loan {
     //
     bool is_allowed_extension = 7;
 }
+
+// The model of a reservation queue process manager.
+//
+message ReservationQueue {
+
+    // The identifier of a process manager
+    ReservationQueueId id = 1;
+}
+
+// The model of a loans extension process manager.
+//
+message LoansExtension {
+
+    // The identifier of a process manager
+    LoansExtensionId id = 1;
+}

--- a/model/src/main/proto/javaclasses/exlibris/values.proto
+++ b/model/src/main/proto/javaclasses/exlibris/values.proto
@@ -82,6 +82,14 @@ message BookCoverURL {
     string value = 1;
 }
 
+// The URL of a book cover.
+//
+message QRcodeURL {
+
+    // The link to the QR-code storage place.
+    string value = 1;
+}
+
 // The book title.
 //
 message BookTitle {

--- a/model/src/main/proto/javaclasses/exlibris/values.proto
+++ b/model/src/main/proto/javaclasses/exlibris/values.proto
@@ -55,20 +55,23 @@ message Isbn62 {
 //
 message BookDetails {
 
+    // The International Standard Book Number.
+    Isbn isbn = 1;
+
     // The URL of a book cover.
-    spine.net.Url book_cover_url = 1;
+    spine.net.Url book_cover_url = 2;
 
     // The DTO of a book title.
-    BookTitle title = 2;
+    BookTitle title = 3;
 
     // Authors' names.
-    AuthorName author = 3;
+    AuthorName author = 4;
 
     // The DTO of a book synopsis.
-    BookSynopsis synopsis = 4;
+    BookSynopsis synopsis = 5;
 
     // A list of book categories.
-    repeated Category categories = 5;
+    repeated Category categories = 6;
 }
 
 // The URL of a book cover.
@@ -148,4 +151,26 @@ message BookDetailsChange {
     BookDetails previous_book_details = 1;
     BookDetails new_book_details = 2;
 
+}
+
+//The International Standard Book Number.
+//
+message Isbn {
+
+    // The string value that contains an ISBN.
+    string value = 1;
+}
+
+// A book item loan status values.
+//
+enum LoanStatus {
+
+    // Used as an undefined value marker.
+    LOAN_UNDEFINED = 0;
+
+    LOAN_RECENT = 1;
+
+    LOAN_OVERDUE = 2;
+
+    LOAN_SOULD_RETURN_SOON = 3;
 }

--- a/model/src/main/proto/javaclasses/exlibris/values.proto
+++ b/model/src/main/proto/javaclasses/exlibris/values.proto
@@ -156,9 +156,11 @@ message WriteOffReason {
 //
 message BookDetailsChange {
 
+    // The previous information about a book.
     BookDetails previous_book_details = 1;
-    BookDetails new_book_details = 2;
 
+    // The updated information about a book.
+    BookDetails new_book_details = 2;
 }
 
 //The International Standard Book Number.

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookEventSubscriber.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookEventSubscriber.java
@@ -26,18 +26,18 @@ import javaclasses.exlibris.c.BookAdded;
 
 public class BookEventSubscriber extends EventSubscriber {
 
-    private static BookAdded event = null;
+    private BookAdded event = null;
 
     @Subscribe
     public void on(BookAdded event) {
         this.event = event;
     }
 
-    public static BookAdded getEvent() {
+    public BookAdded getEvent() {
         return event;
     }
 
-    public static void clear() {
+    public void clear() {
         event = null;
     }
 }

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookRejectionsSubscriber.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/BookRejectionsSubscriber.java
@@ -31,10 +31,10 @@ import javaclasses.exlibris.c.rejection.Rejections;
  */
 public class BookRejectionsSubscriber extends RejectionSubscriber {
 
-    private static Rejections.BookAlreadyExists rejection = null;
-    private static boolean wasCalled = false;
+    private Rejections.BookAlreadyExists rejection = null;
+    private boolean wasCalled = false;
 
-    public static boolean wasCalled() {
+    public boolean wasCalled() {
         return wasCalled;
     }
 
@@ -54,11 +54,11 @@ public class BookRejectionsSubscriber extends RejectionSubscriber {
         wasCalled = true;
     }
 
-    public static Rejections.BookAlreadyExists getRejection() {
+    public Rejections.BookAlreadyExists getRejection() {
         return rejection;
     }
 
-    public static void clear() {
+    public void clear() {
         rejection = null;
         wasCalled = false;
     }

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -118,21 +118,19 @@ public class InventoryCommandFactory {
 
     public static AppendInventory appendInventoryInstance() {
 
-        final AppendInventory result = appendInventoryInstance(inventoryId, inventoryItemId, userId,
-                                                               rfid);
+        final AppendInventory result = appendInventoryInstance(inventoryId, inventoryItemId,
+                                                               userId);
         return result;
     }
 
     public static AppendInventory appendInventoryInstance(InventoryId inventoryId,
                                                           InventoryItemId inventoryItemId,
-                                                          UserId userId, Rfid rfid) {
+                                                          UserId userId) {
 
         AppendInventory result = AppendInventory.newBuilder()
                                                 .setInventoryId(inventoryId)
                                                 .setInventoryItemId(inventoryItemId)
                                                 .setLibrarianId(userId)
-                                                .setRfid(rfid)
-
                                                 .build();
         return result;
     }

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -30,18 +30,23 @@ import javaclasses.exlibris.LoanId;
 import javaclasses.exlibris.Rfid;
 import javaclasses.exlibris.UserId;
 import javaclasses.exlibris.WriteOffReason;
+import javaclasses.exlibris.c.AllowLoansExtension;
 import javaclasses.exlibris.c.AppendInventory;
 import javaclasses.exlibris.c.BorrowBook;
 import javaclasses.exlibris.c.CancelReservation;
 import javaclasses.exlibris.c.ExtendLoanPeriod;
+import javaclasses.exlibris.c.ForbidLoansExtension;
 import javaclasses.exlibris.c.LoanPeriodExtended;
 import javaclasses.exlibris.c.MarkLoanOverdue;
+import javaclasses.exlibris.c.MarkLoanShouldReturnSoon;
 import javaclasses.exlibris.c.MarkReservationExpired;
 import javaclasses.exlibris.c.ReportLostBook;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.ReturnBook;
 import javaclasses.exlibris.c.SatisfyReservation;
 import javaclasses.exlibris.c.WriteBookOff;
+
+import java.util.List;
 
 import static io.spine.time.Time.getCurrentTime;
 
@@ -160,6 +165,15 @@ public class InventoryCommandFactory {
         return result;
     }
 
+    public static MarkLoanShouldReturnSoon markLoanShouldReturnSoon(LoanId loanId,
+                                                                    InventoryId inventoryId) {
+        final MarkLoanShouldReturnSoon result = MarkLoanShouldReturnSoon.newBuilder()
+                                                                        .setLoanId(loanId)
+                                                                        .setInventoryId(inventoryId)
+                                                                        .build();
+        return result;
+    }
+
     public static WriteBookOff writeBookOffInstance() {
 
         final WriteBookOff result = writeBookOffInstance(inventoryId, inventoryItemId, userId,
@@ -253,14 +267,14 @@ public class InventoryCommandFactory {
         return result;
     }
 
-    public static MarkReservationExpired reservationPickUpPeriodInstanceExpired() {
+    public static MarkReservationExpired markReservationExpiredInstance() {
 
-        final MarkReservationExpired result = reservationPickUpPeriodInstanceExpired(inventoryId,
-                                                                                     userId);
+        final MarkReservationExpired result = markReservationExpiredInstance(inventoryId,
+                                                                             userId);
         return result;
     }
 
-    public static MarkReservationExpired reservationPickUpPeriodInstanceExpired(
+    public static MarkReservationExpired markReservationExpiredInstance(
             InventoryId inventoryId,
             UserId userId) {
         MarkReservationExpired result = MarkReservationExpired.newBuilder()
@@ -277,6 +291,27 @@ public class InventoryCommandFactory {
 
         return result;
 
+    }
+
+    public static ForbidLoansExtension forbidLoansExtensionInstance(InventoryId inventoryId,
+                                                                    List<UserId> userIds) {
+
+        final ForbidLoansExtension result = ForbidLoansExtension.newBuilder()
+                                                                .setInventoryId(inventoryId)
+                                                                .addAllBorrowers(userIds)
+                                                                .build();
+        return result;
+
+    }
+
+    public static AllowLoansExtension allowLoansExtensionInstance(InventoryId inventoryId,
+                                                                  List<UserId> userIds) {
+
+        final AllowLoansExtension result = AllowLoansExtension.newBuilder()
+                                                              .setInventoryId(inventoryId)
+                                                              .addAllBorrowers(userIds)
+                                                              .build();
+        return result;
     }
 
     public static ExtendLoanPeriod extendLoanPeriodInstance(InventoryId inventoryId, LoanId loanId,

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -37,6 +37,7 @@ import javaclasses.exlibris.c.CancelReservation;
 import javaclasses.exlibris.c.ExtendLoanPeriod;
 import javaclasses.exlibris.c.ForbidLoansExtension;
 import javaclasses.exlibris.c.LoanPeriodExtended;
+import javaclasses.exlibris.c.MarkBookAsAvailable;
 import javaclasses.exlibris.c.MarkLoanOverdue;
 import javaclasses.exlibris.c.MarkLoanShouldReturnSoon;
 import javaclasses.exlibris.c.MarkReservationExpired;
@@ -217,6 +218,13 @@ public class InventoryCommandFactory {
                                                       .setInventoryId(inventoryId)
                                                       .setUserId(userId)
                                                       .build();
+        return result;
+    }
+
+    public static MarkBookAsAvailable markBookAsAvailableInstance() {
+        MarkBookAsAvailable result = MarkBookAsAvailable.newBuilder()
+                                                        .setInventoryId(inventoryId)
+                                                        .build();
         return result;
     }
 

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryCommandFactory.java
@@ -40,6 +40,7 @@ import javaclasses.exlibris.c.MarkReservationExpired;
 import javaclasses.exlibris.c.ReportLostBook;
 import javaclasses.exlibris.c.ReserveBook;
 import javaclasses.exlibris.c.ReturnBook;
+import javaclasses.exlibris.c.SatisfyReservation;
 import javaclasses.exlibris.c.WriteBookOff;
 
 import static io.spine.time.Time.getCurrentTime;
@@ -179,7 +180,6 @@ public class InventoryCommandFactory {
     }
 
     public static ReserveBook reserveBookInstance() {
-
         final ReserveBook result = reserveBookInstance(userId, inventoryId);
         return result;
     }
@@ -189,6 +189,20 @@ public class InventoryCommandFactory {
                                         .setInventoryId(inventoryId)
                                         .setUserId(userId)
                                         .build();
+        return result;
+    }
+
+    public static SatisfyReservation satisfyReservationInstance() {
+        final SatisfyReservation result = satisfyReservationInstance(userId, inventoryId);
+        return result;
+    }
+
+    public static SatisfyReservation satisfyReservationInstance(UserId userId,
+                                                                InventoryId inventoryId) {
+        SatisfyReservation result = SatisfyReservation.newBuilder()
+                                                      .setInventoryId(inventoryId)
+                                                      .setUserId(userId)
+                                                      .build();
         return result;
     }
 

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
@@ -68,7 +68,7 @@ public class InventoryRejectionsSubscriber extends RejectionSubscriber {
     }
 
     @Subscribe
-    public void on(Rejections.CannotWriteMissingBookOff rejection) {
+    public void on(Rejections.CannotWriteBookOff rejection) {
         wasCalled = true;
     }
 

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
@@ -31,9 +31,9 @@ import javaclasses.exlibris.c.rejection.Rejections;
  */
 public class InventoryRejectionsSubscriber extends RejectionSubscriber {
 
-    private static boolean wasCalled = false;
+    private boolean wasCalled = false;
 
-    public static boolean wasCalled() {
+    public boolean wasCalled() {
         return wasCalled;
     }
 
@@ -77,7 +77,7 @@ public class InventoryRejectionsSubscriber extends RejectionSubscriber {
         wasCalled = true;
     }
 
-    public static void clear() {
+    public void clear() {
         wasCalled = false;
     }
 }

--- a/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
+++ b/testutil-api/src/main/java/javaclasses/exlibris/testdata/InventoryRejectionsSubscriber.java
@@ -77,6 +77,11 @@ public class InventoryRejectionsSubscriber extends RejectionSubscriber {
         wasCalled = true;
     }
 
+    @Subscribe
+    public void on(Rejections.CannotReserveAvailableBook rejection) {
+        wasCalled = true;
+    }
+
     public void clear() {
         wasCalled = false;
     }


### PR DESCRIPTION
In this PR the model refactoring was performed.
The main issue was to simplify inventory aggregate. For this reason, the `ReservationQueueProcman` and the `LoansExtensionProcman` process managers were implemented to manage the reservation queue and loans extension status.
Both process managers are designed as `InventoryAggregate` services. 
They use subscriber methods to react to specific events from aggregate and dispatch specific commands that manage the reservation queue and loans status changes.
 
`ReservationQueueProcman`  reacts on all aggregate events that signalize the available inventory item occurs in the inventory:
- `BookReturned`
- `InventoryAppended`
- `ReservationPickUpPeriodExpired`
- `ReservationCanceled` 

As a result of reacting to those events, process manager decides the inventory item function: 
- to become available for free borrowing (dispatch `MarkBookAsAvailable`)
- to satisfy someone's reservation (dispatch `SatisfyReservation`)
The reservation choice depends on its position in the reservations list in the aggregate state. The eldest one is chosen.

`LoansExtensionProcman` enters into work when the reservation list changes its state:
- `ReservationAdded`
- `BookReadyToPickup`
- `ReservationCanceled`

As a result of reacting to those events, process manager tries to provide each unsatisfied reservation with one forbidden for extension loan.

**`ReservationCanceled` example:** 
**Inventory state before:**
Reservations: reservation1(unsatisfied), reservation2(unsatisfied) 
Loans:  loan1(forbidden to extend), loan2(forbidden to extend), loan3

**After reservation1 was canceled:**
Reservations: reservation2(unsatisfied) 
Loans:   loan1(forbidden to extend), loan2, loan3



`BookReadyToPickup` example:
**Inventory state before:**
Reservations: reservation1(unsatisfied)
Loans:  loan1(forbidden to extend), loan2, loan3

**After loan2 was removed as a result of book returned.**
Reservations: reservation2(satisfied) 
Loans:   loan1, loan3



`ReservationAdded` example:
**Inventory state before:**
Reservations: reservation1(unsatisfied)
Loans:  loan1(forbidden to extend), loan2, loan3

**After addition of reservation**
Reservations: reservation1(unsatisfied), reservation2(unsatisfied) 
Loans:  loan1(forbidden to extend), loan2(forbidden to extend), loan3

Those changes to aggregate state are performed by dispatching one of following commands:
- `ForbidLoansExtension`
- `AllowLoansExtension`